### PR TITLE
[FIX] Replace property name of geo coordinates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea
+/.vscode

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -164,6 +164,11 @@ class NodeIndexer extends AbstractNodeIndexer
                 $document['__uri'] = $uri;
             }
 
+            if (array_key_exists('__geo', $document)) {
+                $document['_geo'] = $document['__geo'];
+                unset($document['__geo']);
+            }
+
             return $document;
         }
 

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ You can set your desired `width`, `height` and optional `allowCropping` values i
 
 ## 📍 Geosearch
 
-Meilisearch supports filtering and sorting on geographic location. For this feature to work, your nodes should supply the `_geo` property with an object of `lat`/`lng` values. An easy way to achieve this is to use a proxy property:
+Meilisearch supports filtering and sorting on geographic location. For this feature to work, your nodes should supply the `__geo` property with an object of `lat`/`lng` values. An easy way to achieve this is to use a proxy property:
 
 ```
 'Neos.Neos:Document':
@@ -244,7 +244,7 @@ Meilisearch supports filtering and sorting on geographic location. For this feat
       type: 'string'
       ui:
         label: 'Longitude'
-    _geo:
+    __geo:
       search:
         indexing: "${{lat: node.properties.latitude, lng: node.properties.longitude}}"
 ```


### PR DESCRIPTION
Property names with only one underscore are not allowed. They will cause an error in the frontend. So you should put the geo coordinates in `__geo`. In the node indexer the array key is replaced by `_geo`. This way the property mapping works correctly with Meilisearch.