### PR TITLE
Fix: Add missing indexing rule for hiddenInIndex

### DIFF
--- a/Configuration/NodeTypes.yaml
+++ b/Configuration/NodeTypes.yaml
@@ -75,6 +75,9 @@
       isRoot: true
       enable: true
   properties:
+    _hiddenInIndex:
+      search:
+        indexing: "${node.hiddenInIndex}"
     title:
       search:
         fulltextExtractor: "${Indexing.extractHtmlTags(node.properties.title)}"


### PR DESCRIPTION
Otherwise, `_ hiddenInIndex` is always `null`