### PR TITLE
Allow no baseUri and no domain set

### DIFF
--- a/Classes/Domain/Service/NodeLinkService.php
+++ b/Classes/Domain/Service/NodeLinkService.php
@@ -1,0 +1,71 @@
+<?php
+declare(strict_types=1);
+
+namespace Medienreaktor\Meilisearch\Domain\Service;
+
+use Medienreaktor\Meilisearch\Domain\Service\RequestService;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Neos\Service\LinkingService;
+use Neos\Eel\FlowQuery\FlowQuery;
+use Neos\ContentRepository\Domain\Service\Context;
+
+/**
+ * Get links from nodes in the CLI
+ *
+ * @Flow\Scope("singleton")
+ */
+class NodeLinkService
+{
+
+     /**
+     * @Flow\Inject
+     * @var LinkingService
+     */
+    protected $linkingService;
+
+    /**
+    * @Flow\Inject
+    * @var RequestService
+    */
+    protected $requestService;
+
+    /**
+     * Get the node uri
+     *
+     * @param NodeInterface $node
+     * @param Context|null $context
+     * @return string|null
+     */
+    public function getNodeUri(NodeInterface $node, ?Context $context = null): ?string
+    {
+        if ($context instanceof Context) {
+            $siteNode = $context->getCurrentSiteNode();
+        }
+        if (!$siteNode instanceof NodeInterface) {
+            $siteNode = $this->getSiteNodeFromNode($node);
+        }
+        $domain = $this->requestService->getDomain($siteNode);
+        $controllerContext = $this->requestService->getControllerContext($domain);
+
+        try {
+            return $this->linkingService->createNodeUri($controllerContext, $node, $siteNode, 'html', !!$domain);
+        } catch (\Exception $e) {
+        }
+        return null;
+    }
+
+    /**
+     * Get the site node from a node
+     *
+     * @param NodeInterface $node
+     * @return NodeInterface
+     */
+    public function getSiteNodeFromNode(NodeInterface $node): NodeInterface
+    {
+        $flowQuery = new FlowQuery([$node]);
+        $nodes = $flowQuery->parents('[instanceof Neos.Neos:Document]')->get();
+
+        return end($nodes);
+    }
+}

--- a/Classes/Domain/Service/RequestService.php
+++ b/Classes/Domain/Service/RequestService.php
@@ -1,0 +1,131 @@
+<?php
+declare(strict_types=1);
+
+namespace Medienreaktor\Meilisearch\Domain\Service;
+
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\ServerRequestAttributes;
+use Neos\Flow\Mvc\ActionRequest;
+use Neos\Flow\Mvc\ActionResponse;
+use Neos\Flow\Mvc\Controller\Arguments;
+use Neos\Flow\Mvc\Controller\ControllerContext;
+use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
+use Neos\Flow\Mvc\Routing\UriBuilder;
+use Neos\Neos\Domain\Repository\SiteRepository;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
+
+/**
+ * Create requests in the CL
+ *
+ * @Flow\Scope("singleton")
+ */
+class RequestService
+{
+    /**
+     * @Flow\Inject
+     * @var UriFactoryInterface
+     */
+    protected $uriFactory;
+
+    /**
+     * @Flow\Inject
+     * @var ServerRequestFactoryInterface
+     */
+    protected $requestFactory;
+
+    /**
+     * @Flow\Inject
+     * @var SiteRepository
+     */
+    protected $siteRepository;
+
+    /**
+     * Get the domain from a node
+     *
+     * @param NodeInterface $node
+     * @return string
+     */
+    public function getDomain(NodeInterface $node): string
+    {
+        try {
+            $nodePath = $node->getPath();
+            $nodePathSegments = explode('/', $nodePath);
+
+            // Seems hacky, but we need to get the site by the node name here
+            // and extract the site name by the node's path
+            if (count($nodePathSegments) >= 3) {
+                $siteName = $nodePathSegments[2];
+                $site = $this->siteRepository->findOneByNodeName($siteName);
+                if ($site && $site->isOnline()) {
+                    $domain = $site->getPrimaryDomain();
+                    if ($domain && $domain->getActive()) {
+                        $uri = $domain->__toString();
+                        if (str_starts_with($uri, 'http://') || str_starts_with($uri, 'https://')) {
+                            return $uri;
+                        }
+                        return 'https://' . $uri;
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the controller context
+    *
+    * @param string|NodeInterface|null $value
+    * @return ControllerContext
+    */
+    public function getControllerContext(string|NodeInterface $value = null): ControllerContext
+    {
+        $actionRequest = $this->createActionRequest($value);
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($actionRequest);
+        $uriBuilder->setCreateAbsoluteUri(false);
+        $controllerContext = new ControllerContext(
+            $actionRequest,
+            new ActionResponse(),
+            new Arguments([]),
+            $uriBuilder
+        );
+        return $controllerContext;
+    }
+
+    /**
+     * Create a action request
+     *
+     * @param string|NodeInterface|null $value
+     * @return ActionRequest
+     */
+    public function createActionRequest(string|NodeInterface $value = null): ActionRequest
+    {
+        $domain = null;
+        if (is_string($value)) {
+            $domain = $value;
+        }
+        if ($value instanceof NodeInterface) {
+            $domain = $this->getDomain($value);
+        }
+        if (!$domain) {
+            $domain = 'http://domain.dummy';
+        }
+
+        $requestUri = $this->uriFactory->createUri($domain);
+        $httpRequest = $this->requestFactory->createServerRequest('get', $requestUri);
+        $parameters = $httpRequest->getAttribute(ServerRequestAttributes::ROUTING_PARAMETERS) ?? RouteParameters::createEmpty();
+        $httpRequest = $httpRequest->withAttribute(
+            ServerRequestAttributes::ROUTING_PARAMETERS,
+            $parameters->withParameter('requestUriHost', $requestUri->getHost())
+        );
+        $actionRequest = ActionRequest::fromHttpRequest($httpRequest);
+        $actionRequest->setFormat('html');
+
+        return $actionRequest;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Medienreaktor.Meilisearch
 
-Integrates Meilisearch into Neos. 
+Integrates Meilisearch into Neos.
 **Compatibility tested with Meilisearch versions 1.2 to 1.8.**
 
 This package aims for simplicity and minimal dependencies. It might therefore not be as sophisticated and extensible as packages like [Flowpack.ElasticSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor), and to achieve this, some code parts had to be copied from these great packages (see Credits).
@@ -85,7 +85,7 @@ Medienreaktor:
         maxValuesPerFacet: 100
 ```
 
-Please do not remove, only extend, above `filterableAttributes`, as they are needed for base functionality to work. After finishing or changing configuration, build the node index once via the CLI command `flow nodeindex:build`. 
+Please do not remove, only extend, above `filterableAttributes`, as they are needed for base functionality to work. After finishing or changing configuration, build the node index once via the CLI command `flow nodeindex:build`.
 
 Document NodeTypes should be configured as fulltext root (this comes by default for all `Neos.Neos:Document` subtypes):
 
@@ -182,7 +182,7 @@ The search query builder supports the following features:
 
 ## ⚡ Usage with JavaScript / React / Vue
 
-If you want to build your frontend with JavaScript, React or Vue, you can completely ignore above Neos and Fusion integration and use `instant-meilisearch`. 
+If you want to build your frontend with JavaScript, React or Vue, you can completely ignore above Neos and Fusion integration and use `instant-meilisearch`.
 
 Please mind these three things:
 
@@ -208,26 +208,19 @@ dimensionsHash = ${String.md5(Json.stringify(site.context.dimensions))}
 
 ### 2. The node URI
 
-The public URI to the node is in the `__uri` attribute of each Meilisearch result hit. 
+The public URI to the node is in the `__uri` attribute of each Meilisearch result hit.
 
 It is generated at indexing time and one reason we create separate index records for each node variant, even if they are redundant due to dimension fallback behaviour. This is in contrast to Flowpack.ElasticSearch.ContentRepositoryAdaptor, where only one record is created and multiple dimensions hashes are assigned.
 
-For the URI generation to work, it is important to have a primary domain assigned to each of your sites.
+If you have assigned a primary domain to your site, the URI will be absolute, otherwise relative.
 
 ### 3. Image URIs
 
-If you need image URIs in your frontend, this can also be configured. First, make sure to set a base URL in your `Settings.yaml`:
+If you need image URIs in your frontend, this can also be configured.
 
-```
-Neos:
-  Flow:
-    http:
-      baseUri: https://example.com/
-```
+Configure your specific properties or all image properties to be indexed:
 
-Then, either configure your specific properties or all image properties to be indexed:
-
-```
+```yaml
 Neos:
   ContentRepository:
     Search:
@@ -237,6 +230,20 @@ Neos:
 ```
 
 You can set your desired `width`, `height` and optional `allowCropping`, `allowUpScaling` and `format` values in the method arguments.
+
+If you have set the `baseUri` in your `Settings.yaml`, the path to your image will be absolute and not asynchron.
+(e.g. `https://example.com/_Resources/Persistent/1/2/3/4/1234567890n/filename-800x600.jpg`)
+
+Otherwise, the image paths will be relative and asynchron (e.g. `/media/thumbnail/12345678-1234-1234-1234-1234567890`)
+
+To set the `baseUri` add your URI to your `Settings.yaml`:
+
+```yaml
+Neos:
+  Flow:
+    http:
+      baseUri: https://example.com/
+```
 
 ## 📍 Geosearch
 


### PR DESCRIPTION
## Allows to index images if no `baseUri` is set

If the `baseUri` is set, the path to the  image will be absolute and not asynchron.
(e.g. `https://example.com/_Resources/Persistent/1/2/3/4/1234567890n/filename-800x600.jpg`)

Otherwise, the image paths will be relative and asynchron (e.g. `/media/thumbnail/12345678-1234-1234-1234-1234567890`)

## Allow to index the URI if no domain is set

If a primary domain is assigned to the site, the URI will be absolute, otherwise relative.

---

The documentation is also adjusted