### PR TITLE
BUGFIX: Index content with correct dimensionsHash for dimension fallback scenarios

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -85,22 +85,70 @@ class NodeIndexCommandController extends CommandController
     {
         $this->indexClient->createIndex();
 
-        $context = $this->contextFactory->create(['workspaceName' => 'live']);
-        $rootNode = $context->getRootNode();
-        $this->traverseNodes($rootNode);
+        // Get all dimension presets and create dimension combinations
+        $dimensionPresets = $this->contentDimensionPresetSource->getAllPresets();
+        $dimensionCombinations = $this->buildDimensionCombinations($dimensionPresets);
+
+        if (empty($dimensionCombinations)) {
+            // No dimensions configured, index without dimensions
+            $this->outputLine('No dimension combinations found, indexing without dimensions');
+            $context = $this->contextFactory->create(['workspaceName' => 'live']);
+            $rootNode = $context->getRootNode();
+            $this->traverseNodes($rootNode);
+        } else {
+            // Index for each dimension combination
+            foreach ($dimensionCombinations as $dimensions) {
+                $dimensionLabel = implode(', ', array_map(fn($k, $v) => "$k: " . implode(',', $v), array_keys($dimensions), $dimensions));
+                $this->outputLine('Indexing dimension: ' . $dimensionLabel);
+
+                $context = $this->contextFactory->create([
+                    'workspaceName' => 'live',
+                    'dimensions' => $dimensions
+                ]);
+                $rootNode = $context->getRootNode();
+                $this->traverseNodes($rootNode, false, $dimensions);
+            }
+        }
 
         $this->outputLine('Finished indexing ' . $this->indexedNodes . ' nodes.');
     }
 
     /**
+     * Build all dimension combinations from presets
+     *
+     * @param array $dimensionPresets
+     * @return array
+     */
+    protected function buildDimensionCombinations(array $dimensionPresets): array
+    {
+        $combinations = [[]];
+
+        foreach ($dimensionPresets as $dimensionName => $dimensionConfig) {
+            $newCombinations = [];
+            foreach ($combinations as $combination) {
+                foreach ($dimensionConfig['presets'] as $presetKey => $preset) {
+                    $newCombination = $combination;
+                    $newCombination[$dimensionName] = $preset['values'];
+                    $newCombinations[] = $newCombination;
+                }
+            }
+            $combinations = $newCombinations;
+        }
+
+        return $combinations;
+    }
+
+    /**
      * @param NodeInterface $currentNode
+     * @param bool $indexAllDimensions Whether to index all dimension combinations for each node
+     * @param array $targetDimensionCombination Optional: Force indexing with this dimension (for shine-through)
      * @throws Exception
      */
-    protected function traverseNodes(NodeInterface $currentNode): void
+    protected function traverseNodes(NodeInterface $currentNode, bool $indexAllDimensions = true, array $targetDimensionCombination = []): void
     {
         if (self::isFulltextRoot($currentNode)) {
             try {
-                $this->nodeIndexer->indexNode($currentNode);
+                $this->nodeIndexer->indexNode($currentNode, null, $indexAllDimensions, false, $targetDimensionCombination);
             } catch (NodeException|IndexingException $exception) {
                 throw new Exception(sprintf('Error during indexing of node %s (%s)', $currentNode->findNodePath(), (string) $currentNode->getNodeAggregateIdentifier()), 1690288327, $exception);
             }
@@ -108,7 +156,7 @@ class NodeIndexCommandController extends CommandController
         }
 
         foreach ($currentNode->findChildNodes() as $childNode) {
-            $this->traverseNodes($childNode);
+            $this->traverseNodes($childNode, $indexAllDimensions, $targetDimensionCombination);
         }
     }
 

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -84,9 +84,10 @@ class NodeIndexer extends AbstractNodeIndexer
      * @param string $targetWorkspace
      * @param bool $indexAllDimensions
      * @param bool $indexFallbackDimensions Whether to index dimensions that fall back to the current nodes dimensions
+     * @param array $targetDimensionCombination Optional: Force indexing with this dimension combination (for shine-through scenarios)
      * @return void
      */
-    public function indexNode(NodeInterface $node, $targetWorkspace = null, $indexAllDimensions = true, $indexFallbackDimensions = true): void
+    public function indexNode(NodeInterface $node, $targetWorkspace = null, $indexAllDimensions = true, $indexFallbackDimensions = true, array $targetDimensionCombination = []): void
     {
         // Make sure this is a fulltext root, e.g. Neos.Neos:Document or subtype
         $node = $this->findFulltextRoot($node);
@@ -131,9 +132,15 @@ class NodeIndexer extends AbstractNodeIndexer
             }
         } else {
             // Index only the current dimension combination without any fallbacks
-            $indexedVariant = $this->indexClient->findAllIdentifiersByIdentifierAndDimensionsHash($nodeIdentifier, $this->dimensionsService->hashByNode($node));
+            // Use targetDimensionCombination if provided (for shine-through/fallback scenarios)
+            $effectiveDimensions = $targetDimensionCombination !== [] ? $targetDimensionCombination : [];
+            $dimensionsHash = $effectiveDimensions !== [] 
+                ? $this->dimensionsService->hash($effectiveDimensions) 
+                : $this->dimensionsService->hashByNode($node);
+            
+            $indexedVariant = $this->indexClient->findAllIdentifiersByIdentifierAndDimensionsHash($nodeIdentifier, $dimensionsHash);
             $this->indexClient->deleteDocuments($indexedVariant);
-            if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier)) {
+            if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier, $effectiveDimensions)) {
                 $documents[] = $nodeVariant;
             }
         }
@@ -146,7 +153,7 @@ class NodeIndexer extends AbstractNodeIndexer
      * Extract node variant properties and fulltext for a given dimension combination
      *
      * @param string $nodeIdentifier
-     * @param array $dimensionCombination
+     * @param array $dimensionCombination The target dimension combination to index for
      * @return array
      */
     protected function extractNodeVariant(string $nodeIdentifier, array $dimensionCombination = []): ?array
@@ -160,11 +167,23 @@ class NodeIndexer extends AbstractNodeIndexer
         $node = $context->getNodeByIdentifier($nodeIdentifier);
 
         if ($node !== null) {
-            $identifier = $this->generateUniqueNodeIdentifier($node);
+            // Use dimensionCombination for hash when provided (handles fallback/shine-through)
+            // This ensures content visible in English is indexed with English hash even if
+            // the underlying node is German
+            $overrideDimensions = $dimensionCombination !== [] ? $dimensionCombination : null;
+            $identifier = $this->generateUniqueNodeIdentifier($node, $overrideDimensions);
             $fulltext = [];
 
             $document = $this->extractPropertiesAndFulltext($node, $fulltext);
             $document['id'] = $identifier;
+
+            // Override __dimensionsHash with the target dimension hash (not the node's internal dimensions)
+            // This is critical for dimension fallback scenarios where German content appears in English
+            if ($dimensionCombination !== []) {
+                $document['__dimensionsHash'] = $this->dimensionsService->hash($dimensionCombination);
+                $document['__dimensions'] = $dimensionCombination;
+            }
+
             if ($this->enableFulltext) {
                 $document['__fulltext'] = $fulltext;
             }
@@ -295,14 +314,19 @@ class NodeIndexer extends AbstractNodeIndexer
      * Generate identifier for index document based on node identifier and dimensions.
      *
      * @param NodeInterface $node
+     * @param array|null $overrideDimensions Optional dimensions to use instead of node's context dimensions
      * @return string
      */
-    protected function generateUniqueNodeIdentifier(NodeInterface $node): string
+    protected function generateUniqueNodeIdentifier(NodeInterface $node, ?array $overrideDimensions = null): string
     {
         $nodeIdentifier = (string) $node->getNodeAggregateIdentifier();
 
-        $dimensionsHash = $this->dimensionsService->hashByNode($node);
+        // Use override dimensions if provided (for fallback/shine-through scenarios)
+        // Otherwise fall back to node's context target dimensions
+        $dimensionsHash = $overrideDimensions !== null
+            ? $this->dimensionsService->hash($overrideDimensions)
+            : $this->dimensionsService->hashByNode($node);
 
-        return $nodeIdentifier.'_'.$dimensionsHash;
+        return $nodeIdentifier . '_' . $dimensionsHash;
     }
 }


### PR DESCRIPTION
When using dimension fallback (shine-through), content from the default dimension (e.g., German) that appears in other dimensions (e.g., English) was only indexed with the default dimension's hash. This caused search to return no results in non-default dimensions.

Changes:
- buildCommand() now iterates over all dimension presets and passes the target dimension combination through the indexing chain
- indexNode() accepts optional targetDimensionCombination parameter
- extractNodeVariant() overrides __dimensionsHash with the target dimension hash for shine-through content
- generateUniqueNodeIdentifier() supports overrideDimensions parameter

This ensures content visible in any dimension is properly indexed with that dimension's hash, making it searchable in all dimensions where it appears.