### PR TITLE
BUGFIX: Use asset-based proxy URIs for search thumbnail indexing

### DIFF
--- a/Classes/Controller/ThumbnailController.php
+++ b/Classes/Controller/ThumbnailController.php
@@ -1,0 +1,77 @@
+<?php
+declare(strict_types=1);
+
+namespace Medienreaktor\Meilisearch\Controller;
+
+use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Controller\ActionController;
+use Neos\Media\Domain\Model\AssetInterface;
+use Neos\Media\Domain\Model\ImageInterface;
+use Neos\Media\Domain\Model\ThumbnailConfiguration;
+use Neos\Media\Domain\Repository\AssetRepository;
+use Neos\Media\Domain\Service\ThumbnailService;
+
+/**
+ * Serves search index thumbnails based on the stable Asset identifier.
+ *
+ * Unlike Neos.Media's ThumbnailController (which uses the ephemeral Thumbnail
+ * entity UUID), this controller resolves thumbnails via the permanent Asset UUID.
+ * This makes indexed URIs survive media:clearthumbnails and resource cleanup.
+ *
+ * @Flow\Scope("singleton")
+ */
+class ThumbnailController extends ActionController
+{
+    /**
+     * @Flow\Inject
+     * @var AssetRepository
+     */
+    protected $assetRepository;
+
+    /**
+     * @Flow\Inject
+     * @var ThumbnailService
+     */
+    protected $thumbnailService;
+
+    /**
+     * Generate or retrieve a thumbnail for the given asset and redirect to its
+     * persistent resource URI.
+     *
+     * @param string $asset The persistence identifier of the asset
+     * @param int $width
+     * @param int $height
+     * @param bool $crop
+     * @param string|null $format
+     */
+    public function thumbnailAction(string $asset, int $width = 600, int $height = 450, bool $crop = true, ?string $format = null): void
+    {
+        /** @var AssetInterface|null $assetObject */
+        $assetObject = $this->assetRepository->findByIdentifier($asset);
+
+        if (!$assetObject instanceof AssetInterface) {
+            $this->response->setStatusCode(404);
+            return;
+        }
+
+        $thumbnailConfiguration = new ThumbnailConfiguration(
+            $width, $width, $height, $height,
+            $crop, false,
+            false,
+            null, $format
+        );
+
+        $thumbnail = $this->thumbnailService->getThumbnail($assetObject, $thumbnailConfiguration);
+
+        if (!$thumbnail instanceof ImageInterface || $thumbnail->getResource() === null) {
+            $this->response->setStatusCode(404);
+            return;
+        }
+
+        $uri = $this->thumbnailService->getUriForThumbnail($thumbnail);
+
+        // Cache the redirect so browsers don't hit this controller on every page view
+        $this->response->setHttpHeader('Cache-Control', 'public, max-age=86400');
+        $this->redirectToUri($uri, 0, 301);
+    }
+}

--- a/Classes/Controller/ThumbnailController.php
+++ b/Classes/Controller/ThumbnailController.php
@@ -44,8 +44,13 @@ class ThumbnailController extends ActionController
      * @param bool $crop
      * @param string|null $format
      */
-    public function thumbnailAction(string $asset, int $width = 600, int $height = 450, bool $crop = true, ?string $format = null): void
-    {
+    public function thumbnailAction(
+        string $asset,
+        int $width = 600,
+        int $height = 450,
+        bool $crop = true,
+        ?string $format = null
+    ): void {
         /** @var AssetInterface|null $assetObject */
         $assetObject = $this->assetRepository->findByIdentifier($asset);
 
@@ -55,10 +60,15 @@ class ThumbnailController extends ActionController
         }
 
         $thumbnailConfiguration = new ThumbnailConfiguration(
-            $width, $width, $height, $height,
-            $crop, false,
+            $width,
+            $width,
+            $height,
+            $height,
+            $crop,
             false,
-            null, $format
+            false,
+            null,
+            $format
         );
 
         $thumbnail = $this->thumbnailService->getThumbnail($assetObject, $thumbnailConfiguration);

--- a/Classes/Eel/AssetUriHelper.php
+++ b/Classes/Eel/AssetUriHelper.php
@@ -3,29 +3,24 @@ declare(strict_types=1);
 
 namespace Medienreaktor\Meilisearch\Eel;
 
-use Medienreaktor\Meilisearch\Domain\Service\RequestService;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Media\Domain\Model\AssetInterface;
-use Neos\Media\Domain\Model\Thumbnail;
+use Neos\Media\Domain\Model\ImageInterface;
 use Neos\Media\Domain\Model\ThumbnailConfiguration;
-use Neos\Media\Domain\Service\AssetService;
 use Neos\Media\Domain\Service\ThumbnailService;
+use Psr\Log\LoggerInterface;
 
 /**
  * AssetUriHelper
+ *
+ * Generates thumbnail URIs for Meilisearch indexing. Thumbnails are always
+ * generated synchronously so the index contains stable /_Resources/ paths
+ * instead of /media/thumbnail/{uuid} controller URIs that become invalid
+ * when thumbnail entities are cleared.
  */
 class AssetUriHelper implements ProtectedContextAwareInterface
 {
-    /**
-     * Resource publisher
-     *
-     * @Flow\Inject
-     * @var AssetService
-     */
-    protected $assetService;
-
     /**
      * @Flow\Inject
      * @var ThumbnailService
@@ -34,24 +29,15 @@ class AssetUriHelper implements ProtectedContextAwareInterface
 
     /**
      * @Flow\Inject
-     * @var UriBuilder
+     * @var LoggerInterface
      */
-    protected $uriBuilder;
+    protected $logger;
 
     /**
-    * @Flow\Inject
-    * @var RequestService
-    */
-    protected $requestService;
-
-    /**
-     * @var string
-     * @Flow\InjectConfiguration(path="http.baseUri", package="Neos.Flow")
-     */
-    protected $baseUri;
-
-    /**
-     * Build asset uri
+     * Build a relative persistent resource URI for the given asset's thumbnail.
+     *
+     * Forces synchronous thumbnail generation and constructs the URI manually
+     * to avoid dependency on Neos.Flow.http.baseUri (unavailable in CLI).
      *
      * @param AssetInterface|AssetInterface[]|null $value
      * @param integer $width
@@ -67,29 +53,35 @@ class AssetUriHelper implements ProtectedContextAwareInterface
             return null;
         }
 
-        // If no baseUri is set, we create async thumbnails
-        $async = !$this->baseUri;
-        $thumbnailConfiguration = new ThumbnailConfiguration($width, $width, $height, $height, $allowCropping, $allowUpScaling, $async, format: $format);
+        try {
+            $thumbnailConfiguration = new ThumbnailConfiguration(
+                $width, $width, $height, $height,
+                $allowCropping, $allowUpScaling,
+                false,
+                null, $format
+            );
 
-        if ($async) {
-            $thumbnailImage = $this->thumbnailService->getThumbnail($value, $thumbnailConfiguration);
-            if ($thumbnailImage instanceof Thumbnail) {
-                $request = $this->requestService->createActionRequest();
-                $this->uriBuilder->setRequest($request->getMainRequest());
-                $uri = $this->uriBuilder
-                        ->reset()
-                        ->setCreateAbsoluteUri(false)
-                        ->uriFor('thumbnail', ['thumbnail' => $thumbnailImage], 'Thumbnail', 'Neos.Media');
-                return $uri ?: null;
+            $thumbnail = $this->thumbnailService->getThumbnail($value, $thumbnailConfiguration);
+            if (!$thumbnail instanceof ImageInterface) {
+                return null;
             }
-            return null;
-        }
 
-        $thumbnailData = $this->assetService->getThumbnailUriAndSizeForAsset($value, $thumbnailConfiguration);
-        if ($thumbnailData === null) {
+            $resource = $thumbnail->getResource();
+            if ($resource === null) {
+                return null;
+            }
+
+            // Build relative URI matching Flow's FileSystemTarget with subdivideHashPathSegment
+            $sha1 = $resource->getSha1();
+            return '/_Resources/Persistent/'
+                . $sha1[0] . '/' . $sha1[1] . '/' . $sha1[2] . '/' . $sha1[3]
+                . '/' . $sha1 . '/' . rawurlencode($resource->getFilename());
+        } catch (\Exception $e) {
+            $this->logger->warning('Meilisearch AssetUriHelper: Failed to generate thumbnail URI', [
+                'exception' => $e->getMessage(),
+            ]);
             return null;
         }
-        return $thumbnailData['src'];
     }
 
     /**

--- a/Classes/Eel/AssetUriHelper.php
+++ b/Classes/Eel/AssetUriHelper.php
@@ -5,39 +5,31 @@ namespace Medienreaktor\Meilisearch\Eel;
 
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Media\Domain\Model\AssetInterface;
-use Neos\Media\Domain\Model\ImageInterface;
-use Neos\Media\Domain\Model\ThumbnailConfiguration;
-use Neos\Media\Domain\Service\ThumbnailService;
-use Psr\Log\LoggerInterface;
 
 /**
  * AssetUriHelper
  *
- * Generates thumbnail URIs for Meilisearch indexing. Thumbnails are always
- * generated synchronously so the index contains stable /_Resources/ paths
- * instead of /media/thumbnail/{uuid} controller URIs that become invalid
- * when thumbnail entities are cleared.
+ * Generates stable thumbnail proxy URIs for Meilisearch indexing. The URI
+ * encodes the permanent Asset identifier and desired thumbnail dimensions,
+ * so a ThumbnailController can resolve them on-the-fly. This survives
+ * media:clearthumbnails, resource cleanup, and thumbnail regeneration.
  */
 class AssetUriHelper implements ProtectedContextAwareInterface
 {
     /**
      * @Flow\Inject
-     * @var ThumbnailService
+     * @var PersistenceManagerInterface
      */
-    protected $thumbnailService;
+    protected $persistenceManager;
 
     /**
-     * @Flow\Inject
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
-     * Build a relative persistent resource URI for the given asset's thumbnail.
+     * Build a proxy URI that encodes the asset identifier and thumbnail params.
      *
-     * Forces synchronous thumbnail generation and constructs the URI manually
-     * to avoid dependency on Neos.Flow.http.baseUri (unavailable in CLI).
+     * The returned URI is resolved by Medienreaktor\Meilisearch\Controller\ThumbnailController,
+     * which looks up the asset, generates the thumbnail if needed, and redirects
+     * to the current persistent resource URI.
      *
      * @param AssetInterface|AssetInterface[]|null $value
      * @param integer $width
@@ -53,35 +45,22 @@ class AssetUriHelper implements ProtectedContextAwareInterface
             return null;
         }
 
-        try {
-            $thumbnailConfiguration = new ThumbnailConfiguration(
-                $width, $width, $height, $height,
-                $allowCropping, $allowUpScaling,
-                false,
-                null, $format
-            );
-
-            $thumbnail = $this->thumbnailService->getThumbnail($value, $thumbnailConfiguration);
-            if (!$thumbnail instanceof ImageInterface) {
-                return null;
-            }
-
-            $resource = $thumbnail->getResource();
-            if ($resource === null) {
-                return null;
-            }
-
-            // Build relative URI matching Flow's FileSystemTarget with subdivideHashPathSegment
-            $sha1 = $resource->getSha1();
-            return '/_Resources/Persistent/'
-                . $sha1[0] . '/' . $sha1[1] . '/' . $sha1[2] . '/' . $sha1[3]
-                . '/' . $sha1 . '/' . rawurlencode($resource->getFilename());
-        } catch (\Exception $e) {
-            $this->logger->warning('Meilisearch AssetUriHelper: Failed to generate thumbnail URI', [
-                'exception' => $e->getMessage(),
-            ]);
+        $identifier = $this->persistenceManager->getIdentifierByObject($value);
+        if ($identifier === null) {
             return null;
         }
+
+        $params = [];
+        $params['width'] = (int)$width;
+        $params['height'] = (int)$height;
+        if ($allowCropping) {
+            $params['crop'] = 1;
+        }
+        if ($format !== null) {
+            $params['format'] = $format;
+        }
+
+        return '/search/thumbnail/' . $identifier . '?' . http_build_query($params);
     }
 
     /**

--- a/Classes/Eel/AssetUriHelper.php
+++ b/Classes/Eel/AssetUriHelper.php
@@ -59,21 +59,8 @@ class AssetUriHelper implements ProtectedContextAwareInterface
             return null;
         }
 
-        // If no baseUri is set, we create async thumbnails
-        $async = !$this->baseUri;
-        $thumbnailConfiguration = new ThumbnailConfiguration($width, $width, $height, $height, $allowCropping, $allowUpScaling, $async, null, $format);
-
-        if ($async) {
-            $thumbnailImage = $this->thumbnailService->getThumbnail($value, $thumbnailConfiguration);
-            if ($thumbnailImage instanceof Thumbnail) {
-                $request = $this->requestService->createActionRequest();
-                $this->uriBuilder->setRequest($request->getMainRequest());
-                $uri = $this->uriBuilder
-                        ->reset()
-                        ->setCreateAbsoluteUri(false)
-                        ->uriFor('thumbnail', ['thumbnail' => $thumbnailImage], 'Thumbnail', 'Neos.Media');
-                return $uri ?: null;
-            }
+        $identifier = $this->persistenceManager->getIdentifierByObject($value);
+        if ($identifier === null) {
             return null;
         }
 

--- a/Classes/Eel/AssetUriHelper.php
+++ b/Classes/Eel/AssetUriHelper.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace Medienreaktor\Meilisearch\Eel;
 
+use Medienreaktor\Meilisearch\Domain\Service\RequestService;
 use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Mvc\Routing\UriBuilder;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Media\Domain\Model\AssetInterface;
 
@@ -25,6 +27,12 @@ class AssetUriHelper implements ProtectedContextAwareInterface
     protected $persistenceManager;
 
     /**
+     * @Flow\Inject
+     * @var RequestService
+     */
+    protected $requestService;
+
+    /**
      * Build a proxy URI that encodes the asset identifier and thumbnail params.
      *
      * The returned URI is resolved by Medienreaktor\Meilisearch\Controller\ThumbnailController,
@@ -36,11 +44,17 @@ class AssetUriHelper implements ProtectedContextAwareInterface
      * @param integer $height
      * @param boolean $allowCropping
      * @param boolean $allowUpScaling
-     * @param string $format
-     * @return null|string
+     * @param string|null $format
+     * @return string|null
      */
-    public function build($value, $width, $height, $allowCropping = true, $allowUpScaling = true, $format = null)
-    {
+    public function build(
+        $value,
+        $width,
+        $height,
+        $allowCropping = true,
+        $allowUpScaling = true,
+        $format = null
+    ): ?string {
         if (!$value instanceof AssetInterface) {
             return null;
         }
@@ -50,17 +64,30 @@ class AssetUriHelper implements ProtectedContextAwareInterface
             return null;
         }
 
-        $params = [];
-        $params['width'] = (int)$width;
-        $params['height'] = (int)$height;
+        $arguments = [
+            'asset' => $identifier,
+            'width' => (int)$width,
+            'height' => (int)$height,
+        ];
+
         if ($allowCropping) {
-            $params['crop'] = 1;
+            $arguments['crop'] = 1;
         }
         if ($format !== null) {
-            $params['format'] = $format;
+            $arguments['format'] = $format;
         }
 
-        return '/search/thumbnail/' . $identifier . '?' . http_build_query($params);
+        $actionRequest = $this->requestService->createActionRequest();
+        $uriBuilder = new UriBuilder();
+        $uriBuilder->setRequest($actionRequest);
+        $uriBuilder->setCreateAbsoluteUri(false);
+
+        return $uriBuilder->uriFor(
+            'thumbnail',
+            $arguments,
+            'Thumbnail',
+            'Medienreaktor.Meilisearch'
+        ) ?: null;
     }
 
     /**
@@ -69,7 +96,7 @@ class AssetUriHelper implements ProtectedContextAwareInterface
      * @param string $methodName
      * @return boolean
      */
-    public function allowsCallOfMethod($methodName)
+    public function allowsCallOfMethod($methodName): bool
     {
         return true;
     }

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -1,0 +1,14 @@
+privilegeTargets:
+
+  'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
+
+    'Medienreaktor.Meilisearch:SearchThumbnail':
+      matcher: 'method(Medienreaktor\Meilisearch\Controller\ThumbnailController->thumbnailAction())'
+
+roles:
+
+  'Neos.Flow:Everybody':
+    privileges:
+      -
+        privilegeTarget: 'Medienreaktor.Meilisearch:SearchThumbnail'
+        permission: GRANT

--- a/Configuration/Policy.yaml
+++ b/Configuration/Policy.yaml
@@ -1,12 +1,9 @@
 privilegeTargets:
-
   'Neos\Flow\Security\Authorization\Privilege\Method\MethodPrivilege':
-
     'Medienreaktor.Meilisearch:SearchThumbnail':
       matcher: 'method(Medienreaktor\Meilisearch\Controller\ThumbnailController->thumbnailAction())'
 
 roles:
-
   'Neos.Flow:Everybody':
     privileges:
       -

--- a/Configuration/Routes.yaml
+++ b/Configuration/Routes.yaml
@@ -1,0 +1,10 @@
+-
+  name: 'Meilisearch search thumbnail proxy'
+  uriPattern: 'search/thumbnail/{asset}'
+  defaults:
+    '@package': 'Medienreaktor.Meilisearch'
+    '@controller': 'Thumbnail'
+    '@action': 'thumbnail'
+    '@format': 'html'
+  appendExceedingArguments: true
+  httpMethods: ['GET']

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,4 +1,9 @@
 Neos:
+  Flow:
+    mvc:
+      routes:
+        'Medienreaktor.Meilisearch':
+          position: 'before Neos.Neos'
   Neos:
     fusion:
       autoInclude:


### PR DESCRIPTION
## Summary

- Replace unstable `/media/thumbnail/{thumbnailUuid}` and `/_Resources/Persistent/` URIs in the Meilisearch index with self-healing `/search/thumbnail/{assetUuid}?width=...&height=...` proxy URIs
- Add a `ThumbnailController` that resolves the permanent Asset UUID, generates or retrieves the matching thumbnail on-the-fly, and redirects (301, cached 24h) to the current persistent resource URI
- Simplify `AssetUriHelper` to only build the proxy URI from the asset identifier -- no more thumbnail generation during indexing, no dependency on `Neos.Flow.http.baseUri`

## Problem

When indexing thumbnails for Meilisearch search results, the previous implementation stored either:
1. **Async thumbnail controller URIs** (`/media/thumbnail/{uuid}`) -- these reference a `Thumbnail` entity UUID that becomes invalid after `media:clearthumbnails` (e.g. during deployment)
2. **Direct resource URIs** (`/_Resources/Persistent/{sha1}/...`) -- these break when the resource file is garbage-collected or the thumbnail is regenerated with a different hash

Both approaches tie the indexed URI to an ephemeral artifact (entity or file) that can be independently invalidated.

## Solution

The new approach indexes `/search/thumbnail/{assetUuid}?width=600&height=450&crop=1&format=jpg`. The Asset UUID is the most stable identifier in Neos -- it only becomes invalid when an editor explicitly deletes the original asset. A new `ThumbnailController` in the package resolves the asset, generates the thumbnail if needed, and redirects to the current resource URI. This is self-healing: if thumbnails are cleared, the next browser request regenerates them automatically.

## Test plan

- [ ] Run `./flow nodeindex:build --workspace=live` and verify indexed image fields contain `/search/thumbnail/{uuid}?...` URIs
- [ ] Open a search thumbnail URL directly in the browser and confirm it redirects to a `/_Resources/Persistent/...` image
- [ ] Run `./flow media:clearthumbnails`, then open the same search thumbnail URL -- it should regenerate and redirect successfully
- [ ] Verify search results in the frontend display thumbnail images correctly