### PR TITLE
FEATURE: Adds progressbar for indexing

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -87,28 +87,45 @@ class NodeIndexCommandController extends CommandController
 
         $context = $this->contextFactory->create(['workspaceName' => 'live']);
         $rootNode = $context->getRootNode();
-        $this->traverseNodes($rootNode);
 
-        $this->outputLine('Finished indexing ' . $this->indexedNodes . ' nodes.');
+        $this->outputLine('Collecting indexable nodes...');
+        $nodes = [];
+        $this->collectNodes($rootNode, $nodes);
+        $total = count($nodes);
+
+        $this->outputLine('Indexing %d nodes...', [$total]);
+        $this->output->progressStart($total);
+
+        foreach ($nodes as $node) {
+            try {
+                $this->nodeIndexer->indexNode($node);
+            } catch (NodeException|IndexingException $exception) {
+                throw new Exception(sprintf('Error during indexing of node %s (%s)', $node->findNodePath(), (string) $node->getNodeAggregateIdentifier()), 1690288327, $exception);
+            }
+            $this->indexedNodes++;
+            $this->output->progressAdvance();
+        }
+
+        $this->output->progressFinish();
+        $this->outputLine('');
+        $this->outputLine('Finished indexing %d nodes.', [$this->indexedNodes]);
     }
 
     /**
+     * Recursively collects all fulltext root nodes into a flat array so that
+     * the total count is known before indexing begins.
+     *
      * @param NodeInterface $currentNode
-     * @throws Exception
+     * @param NodeInterface[] $nodes
      */
-    protected function traverseNodes(NodeInterface $currentNode): void
+    protected function collectNodes(NodeInterface $currentNode, array &$nodes): void
     {
         if (self::isFulltextRoot($currentNode)) {
-            try {
-                $this->nodeIndexer->indexNode($currentNode);
-            } catch (NodeException|IndexingException $exception) {
-                throw new Exception(sprintf('Error during indexing of node %s (%s)', $currentNode->findNodePath(), (string) $currentNode->getNodeAggregateIdentifier()), 1690288327, $exception);
-            }
-            $this->indexedNodes++;
+            $nodes[] = $currentNode;
         }
 
         foreach ($currentNode->findChildNodes() as $childNode) {
-            $this->traverseNodes($childNode);
+            $this->collectNodes($childNode, $nodes);
         }
     }
 


### PR DESCRIPTION
For the indexing, it can be quite frustrating to have no indicator of the progress. So this change adds a progress bar for the indexing command.

So when running `./flow nodeindex:build`, the amount of indexable nodes will be rendered, and after that, we have a growing progress bar.

Ouput can look like this:
```
ddev flow nodeindex:build
Collecting indexable nodes...
Indexing 9268 nodes...
 9268/9268 [============================] 100%
Finished indexing 9268 nodes.
```