### PR TITLE
FEATURE: Add tenant token Eel helper for frontend search

### DIFF
--- a/Classes/Eel/MeilisearchHelper.php
+++ b/Classes/Eel/MeilisearchHelper.php
@@ -1,0 +1,163 @@
+<?php
+declare(strict_types=1);
+
+namespace Medienreaktor\Meilisearch\Eel;
+
+use Medienreaktor\Meilisearch\Domain\Service\DimensionsService;
+use Meilisearch\Client;
+use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Eel\ProtectedContextAwareInterface;
+use Neos\Flow\Annotations as Flow;
+
+/**
+ * Eel helper for public Meilisearch frontend configuration.
+ */
+class MeilisearchHelper implements ProtectedContextAwareInterface
+{
+    /**
+     * @Flow\Inject
+     * @var DimensionsService
+     */
+    protected $dimensionsService;
+
+    /**
+     * @Flow\InjectConfiguration(path="indexName", package="Medienreaktor.Meilisearch")
+     * @var string
+     */
+    protected $indexName = '';
+
+    /**
+     * @Flow\InjectConfiguration(path="client", package="Medienreaktor.Meilisearch")
+     * @var array
+     */
+    protected $clientSettings = [];
+
+    /**
+     * @Flow\InjectConfiguration(path="tenantToken", package="Medienreaktor.Meilisearch")
+     * @var array
+     */
+    protected $tenantTokenSettings = [];
+
+    /**
+     * Generate a Meilisearch tenant token for frontend searches in the current site and dimension context.
+     *
+     * @param NodeInterface $siteNode
+     * @param array<string, mixed> $dimensions
+     * @param string|null $indexName
+     * @param integer|null $expiresIn
+     * @param array<int, string> $additionalFilters
+     * @return string
+     */
+    public function tenantToken(
+        NodeInterface $siteNode,
+        array $dimensions = [],
+        ?string $indexName = null,
+        ?int $expiresIn = null,
+        array $additionalFilters = []
+    ): string {
+        $apiKey = $this->getTenantTokenApiKey();
+        $apiKeyUid = $this->getTenantTokenApiKeyUid();
+
+        if ($apiKey === '' || $apiKeyUid === '' || strlen($apiKey) <= 8) {
+            return '';
+        }
+
+        $indexName = $indexName ?: $this->indexName;
+        if ($indexName === '') {
+            return '';
+        }
+
+        $client = new Client($this->getClientEndpoint(), $apiKey);
+
+        return $client->generateTenantToken(
+            $apiKeyUid,
+            $this->searchRules($siteNode, $dimensions, $indexName, $additionalFilters),
+            [
+                'apiKey' => $apiKey,
+                'expiresAt' => new \DateTimeImmutable('+' . ($expiresIn ?? $this->getTenantTokenExpiresIn()) . ' seconds'),
+            ]
+        );
+    }
+
+    /**
+     * Build Meilisearch tenant search rules for the current site and dimension context.
+     *
+     * @param NodeInterface $siteNode
+     * @param array<string, mixed> $dimensions
+     * @param string|null $indexName
+     * @param array<int, string> $additionalFilters
+     * @return array<string, array<string, string>>
+     */
+    public function searchRules(
+        NodeInterface $siteNode,
+        array $dimensions = [],
+        ?string $indexName = null,
+        array $additionalFilters = []
+    ): array {
+        $indexName = $indexName ?: $this->indexName;
+
+        return [
+            $indexName => [
+                'filter' => $this->frontendFilter($siteNode, $dimensions, $additionalFilters),
+            ],
+        ];
+    }
+
+    /**
+     * Build the public frontend search filter for the given site and dimension context.
+     *
+     * @param NodeInterface $siteNode
+     * @param array<string, mixed> $dimensions
+     * @param array<int, string> $additionalFilters
+     * @return string
+     */
+    public function frontendFilter(NodeInterface $siteNode, array $dimensions = [], array $additionalFilters = []): string
+    {
+        $siteNodePath = (string)$siteNode->getPath();
+        $dimensionsHash = $this->dimensionsService->hash($dimensions ?: $siteNode->getContext()->getDimensions());
+        $filters = [
+            '(__parentPath = "' . $this->escapeFilterValue($siteNodePath) . '" OR __path = "' . $this->escapeFilterValue($siteNodePath) . '")',
+            '__dimensionsHash = "' . $this->escapeFilterValue($dimensionsHash) . '"',
+            '_hidden = false',
+            '_hiddenInIndex = false',
+        ];
+
+        return implode(' AND ', array_merge($filters, array_filter($additionalFilters)));
+    }
+
+    /**
+     * @param string $methodName
+     * @return boolean
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
+    }
+
+    private function getTenantTokenApiKey(): string
+    {
+        return (string)($this->tenantTokenSettings['apiKey'] ?? $this->clientSettings['readonlyApiKey'] ?? '');
+    }
+
+    private function getTenantTokenApiKeyUid(): string
+    {
+        return (string)($this->tenantTokenSettings['apiKeyUid'] ?? $this->clientSettings['readonlyApiKeyUid'] ?? '');
+    }
+
+    private function getTenantTokenExpiresIn(): int
+    {
+        $expiresIn = (int)($this->tenantTokenSettings['expiresIn'] ?? 3600);
+        return $expiresIn > 0 ? $expiresIn : 3600;
+    }
+
+    private function getClientEndpoint(): string
+    {
+        $endpoint = (string)($this->clientSettings['endpoint'] ?? '');
+        return $endpoint !== '' ? $endpoint : 'http://localhost';
+    }
+
+    private function escapeFilterValue(string $value): string
+    {
+        return str_replace(['\\', '"'], ['\\\\', '\\"'], $value);
+    }
+}

--- a/Classes/Eel/MeilisearchHelper.php
+++ b/Classes/Eel/MeilisearchHelper.php
@@ -22,12 +22,6 @@ class MeilisearchHelper implements ProtectedContextAwareInterface
     protected $dimensionsService;
 
     /**
-     * @Flow\InjectConfiguration(path="indexName", package="Medienreaktor.Meilisearch")
-     * @var string
-     */
-    protected $indexName = '';
-
-    /**
      * @Flow\InjectConfiguration(path="client", package="Medienreaktor.Meilisearch")
      * @var array
      */
@@ -44,15 +38,15 @@ class MeilisearchHelper implements ProtectedContextAwareInterface
      *
      * @param NodeInterface $siteNode
      * @param array<string, mixed> $dimensions
-     * @param string|null $indexName
+     * @param string $indexName
      * @param integer|null $expiresIn
      * @param array<int, string> $additionalFilters
      * @return string
      */
     public function tenantToken(
         NodeInterface $siteNode,
-        array $dimensions = [],
-        ?string $indexName = null,
+        array $dimensions,
+        string $indexName,
         ?int $expiresIn = null,
         array $additionalFilters = []
     ): string {
@@ -63,7 +57,6 @@ class MeilisearchHelper implements ProtectedContextAwareInterface
             return '';
         }
 
-        $indexName = $indexName ?: $this->indexName;
         if ($indexName === '') {
             return '';
         }
@@ -90,18 +83,16 @@ class MeilisearchHelper implements ProtectedContextAwareInterface
      *
      * @param NodeInterface $siteNode
      * @param array<string, mixed> $dimensions
-     * @param string|null $indexName
+     * @param string $indexName
      * @param array<int, string> $additionalFilters
      * @return array<string, array<string, string>>
      */
     public function searchRules(
         NodeInterface $siteNode,
-        array $dimensions = [],
-        ?string $indexName = null,
+        array $dimensions,
+        string $indexName,
         array $additionalFilters = []
     ): array {
-        $indexName = $indexName ?: $this->indexName;
-
         return [
             $indexName => [
                 'filter' => $this->frontendFilter($siteNode, $dimensions, $additionalFilters),

--- a/Classes/Eel/MeilisearchHelper.php
+++ b/Classes/Eel/MeilisearchHelper.php
@@ -38,7 +38,7 @@ class MeilisearchHelper implements ProtectedContextAwareInterface
      *
      * @param NodeInterface $siteNode
      * @param array<string, mixed> $dimensions
-     * @param string $indexName
+     * @param string $indexName Meilisearch index name. The package default value is `neos`.
      * @param integer|null $expiresIn
      * @param array<int, string> $additionalFilters
      * @return string
@@ -83,7 +83,7 @@ class MeilisearchHelper implements ProtectedContextAwareInterface
      *
      * @param NodeInterface $siteNode
      * @param array<string, mixed> $dimensions
-     * @param string $indexName
+     * @param string $indexName Meilisearch index name. The package default value is `neos`.
      * @param array<int, string> $additionalFilters
      * @return array<string, array<string, string>>
      */

--- a/Classes/Eel/MeilisearchHelper.php
+++ b/Classes/Eel/MeilisearchHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Medienreaktor\Meilisearch\Eel;
@@ -69,13 +70,18 @@ class MeilisearchHelper implements ProtectedContextAwareInterface
 
         $client = new Client($this->getClientEndpoint(), $apiKey);
 
+        $tokenOptions = [
+            'apiKey' => $apiKey,
+        ];
+        $effectiveExpiresIn = $expiresIn ?? $this->getTenantTokenExpiresIn();
+        if ($effectiveExpiresIn > 0) {
+            $tokenOptions['expiresAt'] = new \DateTimeImmutable('+' . $effectiveExpiresIn . ' seconds');
+        }
+
         return $client->generateTenantToken(
             $apiKeyUid,
             $this->searchRules($siteNode, $dimensions, $indexName, $additionalFilters),
-            [
-                'apiKey' => $apiKey,
-                'expiresAt' => new \DateTimeImmutable('+' . ($expiresIn ?? $this->getTenantTokenExpiresIn()) . ' seconds'),
-            ]
+            $tokenOptions
         );
     }
 
@@ -146,8 +152,8 @@ class MeilisearchHelper implements ProtectedContextAwareInterface
 
     private function getTenantTokenExpiresIn(): int
     {
-        $expiresIn = (int)($this->tenantTokenSettings['expiresIn'] ?? 3600);
-        return $expiresIn > 0 ? $expiresIn : 3600;
+        $expiresIn = (int)($this->tenantTokenSettings['expiresIn'] ?? 0);
+        return $expiresIn > 0 ? $expiresIn : 0;
     }
 
     private function getClientEndpoint(): string

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -27,7 +27,7 @@ Medienreaktor:
       readonlyApiKey: ''
       readonlyApiKeyUid: ''
     tenantToken:
-      expiresIn: 3600
+      expiresIn: 0
     settings:
       displayedAttributes:
         - '*'

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -18,7 +18,6 @@ Neos:
       Meilisearch: Medienreaktor\Meilisearch\Eel\MeilisearchHelper
 Medienreaktor:
   Meilisearch:
-    indexName: ''
     enableFulltext: true
     neededAttributesForIndex: []
     client:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -12,13 +12,22 @@ Neos:
         Json: Neos\Eel\Helper\JsonHelper
         AssetUri: Medienreaktor\Meilisearch\Eel\AssetUriHelper
         Dimensions: Medienreaktor\Meilisearch\Eel\DimensionsHelper
+  Fusion:
+    defaultContext:
+      Dimensions: Medienreaktor\Meilisearch\Eel\DimensionsHelper
+      Meilisearch: Medienreaktor\Meilisearch\Eel\MeilisearchHelper
 Medienreaktor:
   Meilisearch:
+    indexName: ''
     enableFulltext: true
     neededAttributesForIndex: []
     client:
       endpoint: ''
       apiKey: ''
+      readonlyApiKey: ''
+      readonlyApiKeyUid: ''
+    tenantToken:
+      expiresIn: 3600
     settings:
       displayedAttributes:
         - '*'

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ The search query builder supports the following features:
 
 If you want to build your frontend with JavaScript, React or Vue, you can completely ignore above Neos and Fusion integration and use `instant-meilisearch`.
 
-Please mind these three things:
+Please mind these things:
 
 ### 1. Filtering for node context and dimensions
 
@@ -231,7 +231,54 @@ nodePath = ${site.path}
 dimensionsHash = ${Dimensions.hash(site.context.dimensions)}
 ```
 
-### 2. The node URI
+### 2. Frontend tenant tokens
+
+For browser-based search, prefer a Meilisearch tenant token over exposing a plain search key. The `Meilisearch` Eel helper is available in Fusion and can generate a token scoped to the current site node, content dimensions and visibility flags:
+
+```fusion
+searchConfig = Neos.Fusion:DataStructure {
+    host = ${Configuration.setting('Medienreaktor.Meilisearch.client.endpoint')}
+    indexName = 'neos'
+    apiKey = ${Meilisearch.tenantToken(site, site.context.dimensions, 'neos')}
+}
+```
+
+The third argument is the Meilisearch index name. The package default index name is `neos`; pass your project-specific index name if you use a different one.
+
+The generated token enforces this filter:
+
+```text
+(__parentPath = "$siteNodePath" OR __path = "$siteNodePath") AND __dimensionsHash = "$dimensionsHash" AND _hidden = false AND _hiddenInIndex = false
+```
+
+Configure a Meilisearch search key and its key UID for token generation:
+
+```yaml
+Medienreaktor:
+  Meilisearch:
+    client:
+      endpoint: 'https://your-meilisearch-instance'
+      readonlyApiKey: '%env:MEILISEARCH_SEARCH_API_KEY%'
+      readonlyApiKeyUid: '%env:MEILISEARCH_SEARCH_API_KEY_UID%'
+    tenantToken:
+      expiresIn: 0
+```
+
+`tenantToken.expiresIn: 0` is the default and creates a token without an expiry claim. This is useful when the token is rendered through cached Fusion output. Set a positive value in seconds only if your rendered frontend configuration is not cached beyond that token lifetime.
+
+You can pass additional Meilisearch filter expressions as the fifth argument:
+
+```fusion
+apiKey = ${Meilisearch.tenantToken(site, site.context.dimensions, 'neos', null, ['__nodeType = "Neos.Neos:Document"'])}
+```
+
+If you only need the filter string and manage the key yourself, use:
+
+```fusion
+filter = ${Meilisearch.frontendFilter(site, site.context.dimensions)}
+```
+
+### 3. The node URI
 
 The public URI to the node is in the `__uri` attribute of each Meilisearch result hit.
 
@@ -239,7 +286,7 @@ It is generated at indexing time and one reason we create separate index records
 
 If you have assigned a primary domain to your site, the URI will be absolute, otherwise relative.
 
-### 3. Image URIs
+### 4. Image URIs
 
 If you need image URIs in your frontend, this can also be configured.
 


### PR DESCRIPTION
## Summary
- add a Fusion/Eel helper for generating Meilisearch tenant tokens scoped to the current site and dimensions
- expose the helper in the Fusion default context alongside the existing Dimensions helper
- add tenant-token settings for the readonly key, key UID, and optional expiration
- default tenant tokens to non-expiring by omitting exp, which keeps cacheable Fusion output usable

## Notes
The helper keeps frontend searches direct-to-Meilisearch while moving the site/dimension/visibility filters into Meilisearch-enforced tenant token search rules.

## Validation
- php -l Classes/Eel/MeilisearchHelper.php
- phpcs --standard=PSR12 Classes/Eel/MeilisearchHelper.php