### PR TITLE
BUGFIX: Index fallback dimensions and clean up stale variants

### DIFF
--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -85,20 +85,42 @@ class NodeIndexCommandController extends CommandController
     {
         $this->indexClient->createIndex();
 
-        $context = $this->contextFactory->create(['workspaceName' => 'live']);
-        $rootNode = $context->getRootNode();
+        $dimensionPresets = $this->contentDimensionPresetSource->getAllPresets();
+        $dimensionCombinations = $this->buildDimensionCombinations($dimensionPresets);
 
         $this->outputLine('Collecting indexable nodes...');
         $nodes = [];
-        $this->collectNodes($rootNode, $nodes);
+
+        if ($dimensionCombinations === []) {
+            $context = $this->contextFactory->create(['workspaceName' => 'live']);
+            $rootNode = $context->getRootNode();
+            $this->collectNodes($rootNode, $nodes);
+        } else {
+            foreach ($dimensionCombinations as $dimensions) {
+                $context = $this->contextFactory->create([
+                    'workspaceName' => 'live',
+                    'dimensions' => $dimensions
+                ]);
+                $rootNode = $context->getRootNode();
+                $this->collectNodes($rootNode, $nodes, false, false, $dimensions);
+            }
+        }
+
         $total = count($nodes);
 
         $this->outputLine('Indexing %d nodes...', [$total]);
         $this->output->progressStart($total);
 
-        foreach ($nodes as $node) {
+        foreach ($nodes as $nodeToIndex) {
+            $node = $nodeToIndex['node'];
             try {
-                $this->nodeIndexer->indexNode($node);
+                $this->nodeIndexer->indexNode(
+                    $node,
+                    null,
+                    $nodeToIndex['indexAllDimensions'],
+                    $nodeToIndex['indexFallbackDimensions'],
+                    $nodeToIndex['targetDimensionCombination']
+                );
             } catch (NodeException|IndexingException $exception) {
                 throw new Exception(sprintf('Error during indexing of node %s (%s)', $node->findNodePath(), (string) $node->getNodeAggregateIdentifier()), 1690288327, $exception);
             }
@@ -112,20 +134,63 @@ class NodeIndexCommandController extends CommandController
     }
 
     /**
+     * Build all dimension combinations from presets.
+     *
+     * @param array $dimensionPresets
+     * @return array
+     */
+    protected function buildDimensionCombinations(array $dimensionPresets): array
+    {
+        if ($dimensionPresets === []) {
+            return [];
+        }
+
+        $combinations = [[]];
+
+        foreach ($dimensionPresets as $dimensionName => $dimensionConfig) {
+            $newCombinations = [];
+            foreach ($combinations as $combination) {
+                foreach ($dimensionConfig['presets'] as $preset) {
+                    $newCombination = $combination;
+                    $newCombination[$dimensionName] = $preset['values'];
+                    $newCombinations[] = $newCombination;
+                }
+            }
+            $combinations = $newCombinations;
+        }
+
+        return $combinations;
+    }
+
+    /**
      * Recursively collects all fulltext root nodes into a flat array so that
      * the total count is known before indexing begins.
      *
      * @param NodeInterface $currentNode
-     * @param NodeInterface[] $nodes
+     * @param array $nodes
+     * @param bool $indexAllDimensions
+     * @param bool $indexFallbackDimensions
+     * @param array $targetDimensionCombination
      */
-    protected function collectNodes(NodeInterface $currentNode, array &$nodes): void
+    protected function collectNodes(
+        NodeInterface $currentNode,
+        array &$nodes,
+        bool $indexAllDimensions = true,
+        bool $indexFallbackDimensions = true,
+        array $targetDimensionCombination = []
+    ): void
     {
         if (self::isFulltextRoot($currentNode)) {
-            $nodes[] = $currentNode;
+            $nodes[] = [
+                'node' => $currentNode,
+                'indexAllDimensions' => $indexAllDimensions,
+                'indexFallbackDimensions' => $indexFallbackDimensions,
+                'targetDimensionCombination' => $targetDimensionCombination,
+            ];
         }
 
         foreach ($currentNode->findChildNodes() as $childNode) {
-            $this->collectNodes($childNode, $nodes);
+            $this->collectNodes($childNode, $nodes, $indexAllDimensions, $indexFallbackDimensions, $targetDimensionCombination);
         }
     }
 

--- a/Classes/Domain/Service/IndexInterface.php
+++ b/Classes/Domain/Service/IndexInterface.php
@@ -26,6 +26,12 @@ interface IndexInterface
     public function deleteDocuments(array $documents): void;
 
     /**
+     * @param array $filter Filter conditions or Meilisearch filter options
+     * @return void
+     */
+    public function deleteByFilter(array $filter): void;
+
+    /**
      * Delete all documents from the index.
      *
      * @return void

--- a/Classes/Domain/Service/MeilisearchIndex.php
+++ b/Classes/Domain/Service/MeilisearchIndex.php
@@ -104,22 +104,16 @@ class MeilisearchIndex implements IndexInterface
     public function deleteByFilter(array $filter): void
     {
         if ($filter === []) {
-            return; // nichts zu löschen
+            return;
         }
 
-        // Falls bereits das erwartete Options-Array übergeben wurde (['filter' => '...']) direkt verwenden
         if (array_key_exists('filter', $filter)) {
             $options = $filter;
         } else {
-            // Liste von Bedingungen (z.B. ['__identifier = 123', '__dimensionsHash = "abc"']) in einen AND-Ausdruck umwandeln
             $options = ['filter' => implode(' AND ', $filter)];
         }
 
-        try {
-            $this->index->deleteDocuments($options);
-        } catch (\Meilisearch\Exceptions\ApiException $e) {
-            // Optional: Logging hier möglich. Still schlucken oder rethrow? Aktuell still, um Verhalten der anderen Methoden zu spiegeln.
-        }
+        $this->index->deleteDocuments($options);
     }
 
     /**

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -115,8 +115,9 @@ class NodeIndexer extends AbstractNodeIndexer
         // For each dimension combination, extract the node variant properties and fulltext
         $dimensionCombinations = $this->dimensionsService->getDimensionCombinationsForIndexing($node);
         if ($indexAllDimensions && $dimensionCombinations !== []) {
-            $allIndexedVariants = $this->indexClient->findAllIdentifiersByIdentifier($nodeIdentifier);
-            $this->indexClient->deleteDocuments($allIndexedVariants);
+            $this->indexClient->deleteByFilter([
+                '__identifier = "' . $nodeIdentifier . '"'
+            ]);
             foreach ($dimensionCombinations as $combination) {
                 if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier, $combination)) {
                     $documents[] = $nodeVariant;
@@ -128,8 +129,10 @@ class NodeIndexer extends AbstractNodeIndexer
                 // Check if current dimension and all dimensions that fall back to the current nodes dimensions
                 if (in_array($node->getContext()->getDimensions()['language'][0], $combination['language'])) {
                     // delete previously indexed variant with same dimensions
-                    $indexedVariant = $this->indexClient->findAllIdentifiersByIdentifierAndDimensionsHash($nodeIdentifier, $this->dimensionsService->hash($combination));
-                    $this->indexClient->deleteDocuments($indexedVariant);
+                    $this->indexClient->deleteByFilter([
+                        '__identifier = "' . $nodeIdentifier . '"',
+                        '__dimensionsHash = "' . $this->dimensionsService->hash($combination) . '"'
+                    ]);
                     // Index the new node variant
                     if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier, $combination)) {
                         $documents[] = $nodeVariant;
@@ -144,8 +147,10 @@ class NodeIndexer extends AbstractNodeIndexer
                 ? $this->dimensionsService->hash($effectiveDimensions)
                 : $this->dimensionsService->hashByNode($node);
 
-            $indexedVariant = $this->indexClient->findAllIdentifiersByIdentifierAndDimensionsHash($nodeIdentifier, $dimensionsHash);
-            $this->indexClient->deleteDocuments($indexedVariant);
+            $this->indexClient->deleteByFilter([
+                '__identifier = "' . $nodeIdentifier . '"',
+                '__dimensionsHash = "' . $dimensionsHash . '"'
+            ]);
             if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier, $effectiveDimensions)) {
                 $documents[] = $nodeVariant;
             }

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -129,9 +129,9 @@ class NodeIndexer extends AbstractNodeIndexer
                 // Check if current dimension and all dimensions that fall back to the current nodes dimensions
                 if (in_array($node->getContext()->getDimensions()['language'][0], $combination['language'])) {
                     // delete previously indexed variant with same dimensions
-                    $this->indexClient->deleteByFilter([
-                        '__identifier = "' . $nodeIdentifier . '"',
-                        '__dimensionsHash = "' . $this->dimensionsService->hash($combination) . '"'
+                    $dimensionsHash = $this->dimensionsService->hash($combination);
+                    $this->indexClient->deleteDocuments([
+                        $this->generateDocumentIdentifier($nodeIdentifier, $dimensionsHash)
                     ]);
                     // Index the new node variant
                     if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier, $combination)) {
@@ -147,9 +147,8 @@ class NodeIndexer extends AbstractNodeIndexer
                 ? $this->dimensionsService->hash($effectiveDimensions)
                 : $this->dimensionsService->hashByNode($node);
 
-            $this->indexClient->deleteByFilter([
-                '__identifier = "' . $nodeIdentifier . '"',
-                '__dimensionsHash = "' . $dimensionsHash . '"'
+            $this->indexClient->deleteDocuments([
+                $this->generateDocumentIdentifier($nodeIdentifier, $dimensionsHash)
             ]);
             if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier, $effectiveDimensions)) {
                 $documents[] = $nodeVariant;
@@ -338,6 +337,11 @@ class NodeIndexer extends AbstractNodeIndexer
             ? $this->dimensionsService->hash($overrideDimensions)
             : $this->dimensionsService->hashByNode($node);
 
+        return $this->generateDocumentIdentifier($nodeIdentifier, $dimensionsHash);
+    }
+
+    protected function generateDocumentIdentifier(string $nodeIdentifier, string $dimensionsHash): string
+    {
         return $nodeIdentifier . '_' . $dimensionsHash;
     }
 }

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -84,9 +84,16 @@ class NodeIndexer extends AbstractNodeIndexer
      * @param string $targetWorkspace
      * @param bool $indexAllDimensions
      * @param bool $indexFallbackDimensions Whether to index dimensions that fall back to the current nodes dimensions
+     * @param array $targetDimensionCombination Optional: Force indexing with this dimension combination (for shine-through scenarios)
      * @return void
      */
-    public function indexNode(NodeInterface $node, $targetWorkspace = null, $indexAllDimensions = true, $indexFallbackDimensions = true): void
+    public function indexNode(
+        NodeInterface $node,
+        $targetWorkspace = null,
+        $indexAllDimensions = true,
+        $indexFallbackDimensions = true,
+        array $targetDimensionCombination = []
+    ): void
     {
         // Make sure this is a fulltext root, e.g. Neos.Neos:Document or subtype
         $node = $this->findFulltextRoot($node);
@@ -131,9 +138,15 @@ class NodeIndexer extends AbstractNodeIndexer
             }
         } else {
             // Index only the current dimension combination without any fallbacks
-            $indexedVariant = $this->indexClient->findAllIdentifiersByIdentifierAndDimensionsHash($nodeIdentifier, $this->dimensionsService->hashByNode($node));
+            // Use targetDimensionCombination if provided (for shine-through/fallback scenarios)
+            $effectiveDimensions = $targetDimensionCombination !== [] ? $targetDimensionCombination : [];
+            $dimensionsHash = $effectiveDimensions !== []
+                ? $this->dimensionsService->hash($effectiveDimensions)
+                : $this->dimensionsService->hashByNode($node);
+
+            $indexedVariant = $this->indexClient->findAllIdentifiersByIdentifierAndDimensionsHash($nodeIdentifier, $dimensionsHash);
             $this->indexClient->deleteDocuments($indexedVariant);
-            if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier)) {
+            if ($nodeVariant = $this->extractNodeVariant($nodeIdentifier, $effectiveDimensions)) {
                 $documents[] = $nodeVariant;
             }
         }
@@ -146,7 +159,7 @@ class NodeIndexer extends AbstractNodeIndexer
      * Extract node variant properties and fulltext for a given dimension combination
      *
      * @param string $nodeIdentifier
-     * @param array $dimensionCombination
+     * @param array $dimensionCombination The target dimension combination to index for
      * @return array
      */
     protected function extractNodeVariant(string $nodeIdentifier, array $dimensionCombination = []): ?array
@@ -160,11 +173,23 @@ class NodeIndexer extends AbstractNodeIndexer
         $node = $context->getNodeByIdentifier($nodeIdentifier);
 
         if ($node !== null) {
-            $identifier = $this->generateUniqueNodeIdentifier($node);
+            // Use dimensionCombination for hash when provided (handles fallback/shine-through)
+            // This ensures content visible in English is indexed with English hash even if
+            // the underlying node is German
+            $overrideDimensions = $dimensionCombination !== [] ? $dimensionCombination : null;
+            $identifier = $this->generateUniqueNodeIdentifier($node, $overrideDimensions);
             $fulltext = [];
 
             $document = $this->extractPropertiesAndFulltext($node, $fulltext);
             $document['id'] = $identifier;
+
+            // Override __dimensionsHash with the target dimension hash (not the node's internal dimensions)
+            // This is critical for dimension fallback scenarios where German content appears in English
+            if ($dimensionCombination !== []) {
+                $document['__dimensionsHash'] = $this->dimensionsService->hash($dimensionCombination);
+                $document['__dimensions'] = $dimensionCombination;
+            }
+
             if ($this->enableFulltext) {
                 $document['__fulltext'] = $fulltext;
             }
@@ -295,14 +320,19 @@ class NodeIndexer extends AbstractNodeIndexer
      * Generate identifier for index document based on node identifier and dimensions.
      *
      * @param NodeInterface $node
+     * @param array|null $overrideDimensions Optional dimensions to use instead of node's context dimensions
      * @return string
      */
-    protected function generateUniqueNodeIdentifier(NodeInterface $node): string
+    protected function generateUniqueNodeIdentifier(NodeInterface $node, ?array $overrideDimensions = null): string
     {
         $nodeIdentifier = (string) $node->getNodeAggregateIdentifier();
 
-        $dimensionsHash = $this->dimensionsService->hashByNode($node);
+        // Use override dimensions if provided (for fallback/shine-through scenarios)
+        // Otherwise fall back to node's context target dimensions
+        $dimensionsHash = $overrideDimensions !== null
+            ? $this->dimensionsService->hash($overrideDimensions)
+            : $this->dimensionsService->hashByNode($node);
 
-        return $nodeIdentifier.'_'.$dimensionsHash;
+        return $nodeIdentifier . '_' . $dimensionsHash;
     }
 }


### PR DESCRIPTION
## Summary
- index build now iterates configured content dimension combinations so shine-through content is indexed for every target dimension where it is visible
- pass the target dimension combination through node indexing to generate the correct document `id` and `__dimensionsHash`
- delete all existing variants by the filterable `__identifier` during live reindexing instead of searching for displayed primary keys
- delete dimension-specific variants directly by their deterministic primary key when the dimension hash is already known
- expose filter deletion through `IndexInterface` and propagate Meilisearch API failures
- preserve the 2.6.0 progress-bar collection/indexing flow while applying the dimension fallback fix

## Root cause
The indexer searched existing variants and read each hit's `id` before deleting them. Projects that restrict `displayedAttributes` can legitimately hide `id`, which made publishing fail with `Undefined array key "id"`. Variant cleanup now uses filterable internal fields and no longer depends on frontend-visible attributes.

## Verification
- `php -l Classes/Domain/Service/IndexInterface.php`
- `php -l Classes/Domain/Service/MeilisearchIndex.php`
- `php -l Classes/Indexer/NodeIndexer.php` (passes; PHP 8.4 reports the existing nullable-parameter deprecation in `extractPropertiesAndFulltext`)
- `composer validate --no-check-publish` (valid; existing unbound dependency warnings)
- `git diff --check upstream/main..HEAD`
- local DDEV Meilisearch settings applied without `id` in `displayedAttributes`
- focused single-node indexing succeeds while search hits omit `id`
- full local `nodeindex:build` completed for 2,180 nodes across five language dimensions
- Meilisearch queue drained completely and all deletion/addition tasks succeeded (the existing build command still records its expected `index_already_exists` index-creation task); the test aggregate has all five expected variants
