### PR TITLE
Zero-downtime reindex (nodeindex:rebuild)

### DIFF
--- a/.github/workflows/neos9.yml
+++ b/.github/workflows/neos9.yml
@@ -1,0 +1,125 @@
+name: CI (neos9)
+
+on:
+  push:
+    branches: [ neos9 ]
+  pull_request:
+    branches: [ neos9 ]
+  # Lets a release be re-verified without an empty commit.
+  workflow_dispatch:
+
+# Nothing here writes to the repository; the token only lifts Composer's
+# unauthenticated GitHub API rate limit when fetching dist archives.
+permissions:
+  contents: read
+
+# Third-party actions are pinned by commit SHA rather than tag, because a tag can
+# be moved onto different code after review. GitHub's own actions/* are pinned to
+# the major, which GitHub controls and repoints deliberately.
+env:
+  # Installing Neos pulls well over a hundred packages as GitHub dist archives,
+  # which exhausts the 60-per-hour unauthenticated API limit.
+  COMPOSER_AUTH: '{"github-oauth":{"github.com":"${{ secrets.GITHUB_TOKEN }}"}}'
+
+jobs:
+  # Lint is deliberately not part of the test matrix below: style and static
+  # analysis do not vary by PHP version here, so one authoritative run is enough.
+  #
+  # There is deliberately no PHPStan baseline on this branch, and no composer script
+  # to generate one. The errors a baseline would record are the work this line still
+  # owes after the Neos 9 port — not accepted debt to be silenced in one command.
+  lint:
+    name: Lint (PHP 8.3, highest deps)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # Supplies both the interpreter and Composer, so nothing has to be fetched
+      # from getcomposer.org at job time. The official `composer` image was the
+      # alternative, but it ships exactly one PHP version and so cannot serve the
+      # matrix below.
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.3'
+          # Everything neos/flow and neos/utility-unicode declare, plus what PHPUnit
+          # needs. json, reflection and spl are core in PHP 8 and need no request.
+          extensions: mbstring, xml, xmlreader, zlib, dom, tokenizer
+          tools: composer:v2
+          coverage: none
+
+      # The manifest is this package's contract with every consuming distribution,
+      # and a wrong constraint there is exactly the class of bug that reaches
+      # projects silently. Cheap to check, so check it before anything installs.
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          dependency-versions: highest
+          composer-options: "--prefer-dist"
+
+      - name: Run Linting (PHPStan & PHP CodeSniffer)
+        run: composer lint
+
+  test:
+    name: Test (PHP ${{ matrix.php }}, ${{ matrix.deps }} deps)
+    # GitHub-hosted rather than the org's self-hosted runner: this repository is
+    # public, and the org runner group is set to allows_public_repositories: false,
+    # so a job from here is never claimed and sits queued indefinitely next to an
+    # idle runner. GitHub-hosted minutes are free and unlimited for public repos.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    strategy:
+      # Let every version report rather than killing the rest when the first fails.
+      fail-fast: false
+      matrix:
+        # composer.json declares php ^8.2 with neos/* ^9.0, and both ends of that
+        # are exercised rather than asserted:
+        #
+        #   - `lowest` on 8.2 pins the oldest set the constraints permit, which is
+        #     also the oldest that installs at all: neos/flow ^9 and
+        #     neos/content-repository-search ^5 both require PHP >= 8.2, so there
+        #     is no 8.0/8.1 row to run on this line.
+        #   - `highest` walks up to the newest Neos 9 each interpreter permits.
+        #
+        # 8.5 is left out until Neos 9 supports it.
+        include:
+          - { php: '8.2', deps: 'lowest' }
+          - { php: '8.2', deps: 'highest' }
+          - { php: '8.3', deps: 'highest' }
+          - { php: '8.4', deps: 'highest' }
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, xml, xmlreader, zlib, dom, tokenizer
+          tools: composer:v2
+          coverage: none
+
+      # Resolves from the constraints every time — no composer.lock is committed,
+      # which is what makes the lowest/highest split meaningful. The action caches
+      # the Composer download cache per PHP version and dependency preference.
+      - name: Install dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+        with:
+          dependency-versions: ${{ matrix.deps }}
+          composer-options: "--prefer-dist"
+
+      # Makes the floor claim auditable: the log states which Neos the job actually
+      # ran against, rather than leaving it to be inferred from the matrix name.
+      - name: Show resolved dependency versions
+        run: composer show --direct
+
+      - name: Run Tests (PHPUnit)
+        run: composer test

--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -67,6 +67,7 @@ class NodeIndexCommandController extends CommandController {
      * @throws Exception
      */
     public function buildCommand(?int $limit = null): void {
+        $startTime = microtime(true);
         $this->indexClient->createIndex();
 
         $contentRepositoryId = ContentRepositoryId::fromString('default');
@@ -77,7 +78,7 @@ class NodeIndexCommandController extends CommandController {
         $this->indexedNodes = $this->workspaceIndexer->index($contentRepositoryId, $workspace->workspaceName, limit: $limit, singleCallback: fn() => $this->output->progressAdvance());
         $this->output->progressFinish();
 
-        $this->outputLine('Finished indexing ' . $this->indexedNodes . ' nodes.');
+        $this->outputLine('Finished indexing ' . $this->indexedNodes . ' nodes in ' . round(microtime(true) - $startTime, 1) . 's.');
     }
 
     /**
@@ -92,6 +93,7 @@ class NodeIndexCommandController extends CommandController {
      * @throws Exception
      */
     public function rebuildCommand(?int $limit = null, bool $skipRemoval = true): void {
+        $startTime = microtime(true);
         $contentRepositoryId = ContentRepositoryId::fromString('default');
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $workspace = $contentRepository->findWorkspaceByName(WorkspaceName::forLive());
@@ -118,7 +120,7 @@ class NodeIndexCommandController extends CommandController {
         if ($limit !== null) {
             $this->outputLine('<comment>--limit was set: the live index now holds only a PARTIAL set. Run without --limit for a full index.</comment>');
         }
-        $this->outputLine('Finished zero-downtime rebuild — indexed ' . $this->indexedNodes . ' nodes and swapped the index.');
+        $this->outputLine('Finished zero-downtime rebuild — indexed ' . $this->indexedNodes . ' nodes and swapped the index in ' . round(microtime(true) - $startTime, 1) . 's.');
     }
 
     /**

--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -60,26 +60,65 @@ class NodeIndexCommandController extends CommandController {
     }
 
     /**
-     * Index all nodes.
+     * Index all nodes in-place into the live index.
      *
+     * @param int|null $limit Only index up to this many nodes per dimension (for quick testing)
      * @return void
      * @throws Exception
      */
-    public function buildCommand(): void {
+    public function buildCommand(?int $limit = null): void {
         $this->indexClient->createIndex();
 
         $contentRepositoryId = ContentRepositoryId::fromString('default');
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $workspace = $contentRepository->findWorkspaceByName(WorkspaceName::forLive());
 
-        $contentGraph = $contentRepository->getContentGraph($workspace->workspaceName);
-        $rootNodeAggregate = $contentGraph->findRootNodeAggregateByType(NodeTypeName::fromString('Neos.Neos:Sites'));
-
-
-        $this->output->progressStart();
-        $this->indexedNodes = $this->workspaceIndexer->index($contentRepositoryId, $workspace->workspaceName, singleCallback: fn() => $this->output->progressAdvance());
+        $this->output->progressStart($this->progressMax($contentRepositoryId, $workspace->workspaceName, $limit));
+        $this->indexedNodes = $this->workspaceIndexer->index($contentRepositoryId, $workspace->workspaceName, limit: $limit, singleCallback: fn() => $this->output->progressAdvance());
+        $this->output->progressFinish();
 
         $this->outputLine('Finished indexing ' . $this->indexedNodes . ' nodes.');
+    }
+
+    /**
+     * Zero-downtime reindex: build into a fresh temporary index, then atomically
+     * swap it live. The current index keeps serving complete results the whole
+     * time — no gap, no half-built state. On error the temp index is discarded
+     * and the live index stays untouched.
+     *
+     * @param int|null $limit Only index up to this many nodes per dimension (testing — produces a PARTIAL live index)
+     * @param bool $skipRemoval Skip the per-node delete (safe: the build index is fresh/empty). Disable to benchmark its cost.
+     * @return void
+     * @throws Exception
+     */
+    public function rebuildCommand(?int $limit = null, bool $skipRemoval = true): void {
+        $contentRepositoryId = ContentRepositoryId::fromString('default');
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $workspace = $contentRepository->findWorkspaceByName(WorkspaceName::forLive());
+
+        $buildIndexName = $this->indexClient->createBuildIndex();
+        $this->output->progressStart($this->progressMax($contentRepositoryId, $workspace->workspaceName, $limit));
+        try {
+            $this->indexedNodes = $this->workspaceIndexer->index(
+                $contentRepositoryId,
+                $workspace->workspaceName,
+                limit: $limit,
+                singleCallback: fn() => $this->output->progressAdvance(),
+                skipRemoval: $skipRemoval,
+                targetIndexName: $buildIndexName
+            );
+            $this->output->progressFinish();
+            $this->indexClient->swapBuildIndex($buildIndexName);
+        } catch (\Throwable $e) {
+            $this->indexClient->deleteBuildIndex($buildIndexName);
+            throw $e;
+        }
+
+        $this->outputLine('');
+        if ($limit !== null) {
+            $this->outputLine('<comment>--limit was set: the live index now holds only a PARTIAL set. Run without --limit for a full index.</comment>');
+        }
+        $this->outputLine('Finished zero-downtime rebuild — indexed ' . $this->indexedNodes . ' nodes and swapped the index.');
     }
 
     /**
@@ -88,6 +127,19 @@ class NodeIndexCommandController extends CommandController {
     public function flushCommand(): void {
         $this->indexClient->deleteAllDocuments();
         $this->outputLine('All documents flushed from the index.');
+    }
+
+    /**
+     * Number of progress steps to expect. The indexer visits every node once per
+     * dimension, and $limit caps the count per dimension — so the total advances
+     * are $limit times the number of dimensions.
+     */
+    protected function progressMax(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, ?int $limit): int {
+        if ($limit === null) {
+            return $this->workspaceIndexer->count($contentRepositoryId, $workspaceName);
+        }
+        $dimensionSpacePoints = $this->contentRepositoryRegistry->get($contentRepositoryId)->getVariationGraph()->getDimensionSpacePoints();
+        return $limit * max(1, $dimensionSpacePoints->count());
     }
 
     /**

--- a/Classes/Command/NodeIndexCommandController.php
+++ b/Classes/Command/NodeIndexCommandController.php
@@ -87,7 +87,10 @@ class NodeIndexCommandController extends CommandController {
      * time — no gap, no half-built state. On error the temp index is discarded
      * and the live index stays untouched.
      *
-     * @param int|null $limit Only index up to this many nodes per dimension (testing — produces a PARTIAL live index)
+     * Documents written by other indexers into the same index (assets, PDFs) are
+     * copied over before the swap — see the "indexing.preserveOnRebuild" setting.
+     *
+     * @param int|null $limit Only index up to this many nodes per dimension. This builds a partial index, which is never swapped live — for testing the build itself.
      * @param bool $skipRemoval Skip the per-node delete (safe: the build index is fresh/empty). Disable to benchmark its cost.
      * @return void
      * @throws Exception
@@ -110,16 +113,26 @@ class NodeIndexCommandController extends CommandController {
                 targetIndexName: $buildIndexName
             );
             $this->output->progressFinish();
+            $this->outputLine('');
+
+            if ($limit !== null) {
+                // A capped run holds a fraction of the documents. Swapping it would
+                // do exactly what this command exists to prevent: leave the live
+                // index short of most of its content.
+                $this->indexClient->deleteBuildIndex($buildIndexName);
+                $this->outputLine('<comment>--limit was set: built %d nodes into a partial index and discarded it. The live index is untouched — run without --limit to actually rebuild.</comment>', [$this->indexedNodes]);
+                return;
+            }
+
+            foreach ($this->indexClient->preserveDocuments($buildIndexName) as $label => $preserved) {
+                $this->outputLine('Carried over %d "%s" documents from the live index.', [$preserved, $label]);
+            }
             $this->indexClient->swapBuildIndex($buildIndexName);
         } catch (\Throwable $e) {
             $this->indexClient->deleteBuildIndex($buildIndexName);
             throw $e;
         }
 
-        $this->outputLine('');
-        if ($limit !== null) {
-            $this->outputLine('<comment>--limit was set: the live index now holds only a PARTIAL set. Run without --limit for a full index.</comment>');
-        }
         $this->outputLine('Finished zero-downtime rebuild — indexed ' . $this->indexedNodes . ' nodes and swapped the index in ' . round(microtime(true) - $startTime, 1) . 's.');
     }
 

--- a/Classes/Domain/Service/IndexInterface.php
+++ b/Classes/Domain/Service/IndexInterface.php
@@ -21,6 +21,15 @@ interface IndexInterface
     public function createBuildIndex(): string;
 
     /**
+     * Copy documents this rebuild does not produce itself (e.g. the asset
+     * indexer's) from the live index into the build index, so the swap does not
+     * drop them. Driven by the "indexing.preserveOnRebuild" setting.
+     *
+     * @return array<string,int> Number of copied documents per configured label
+     */
+    public function preserveDocuments(string $buildIndexName): array;
+
+    /**
      * Atomically swap a freshly-built index into the live index, then drop the
      * old data. Aborts (leaving live untouched) if the build index is empty.
      */

--- a/Classes/Domain/Service/IndexInterface.php
+++ b/Classes/Domain/Service/IndexInterface.php
@@ -14,16 +14,36 @@ interface IndexInterface
     public function createIndex(): void;
 
     /**
+     * Create a fresh, fully-configured build index for a zero-downtime rebuild
+     * and return its name. Index into it via addDocuments($docs, $name), then
+     * hand the name to swapBuildIndex().
+     */
+    public function createBuildIndex(): string;
+
+    /**
+     * Atomically swap a freshly-built index into the live index, then drop the
+     * old data. Aborts (leaving live untouched) if the build index is empty.
+     */
+    public function swapBuildIndex(string $buildIndexName): void;
+
+    /**
+     * Discard a build index (error cleanup); live is left untouched.
+     */
+    public function deleteBuildIndex(string $buildIndexName): void;
+
+    /**
      * @param array $documents Documents to add to the index
+     * @param string|null $targetIndexName Write to this index instead of the live one
      * @return void
      */
-    public function addDocuments(array $documents): void;
+    public function addDocuments(array $documents, ?string $targetIndexName = null): void;
 
     /**
      * @param array $documents Documents to delete from the index
+     * @param string|null $targetIndexName Delete from this index instead of the live one
      * @return void
      */
-    public function deleteDocuments(array $documents): void;
+    public function deleteDocuments(array $documents, ?string $targetIndexName = null): void;
 
     /**
      * Delete all documents from the index.
@@ -36,9 +56,10 @@ interface IndexInterface
      * Delete documents matching the given Meilisearch filter expression(s).
      *
      * @param array<int,string>|string $filter Filter clauses (joined with AND) or raw filter string
+     * @param string|null $targetIndexName Delete from this index instead of the live one
      * @return void
      */
-    public function deleteByFilter(array|string $filter): void;
+    public function deleteByFilter(array|string $filter, ?string $targetIndexName = null): void;
 
     /**
      * Look up all document ids that share the same logical __identifier.

--- a/Classes/Domain/Service/MeilisearchIndex.php
+++ b/Classes/Domain/Service/MeilisearchIndex.php
@@ -54,6 +54,70 @@ class MeilisearchIndex implements IndexInterface {
         $this->index = $this->client->index($this->indexName);
     }
 
+    protected function targetIndex(?string $targetIndexName): Indexes {
+        return $targetIndexName !== null ? $this->client->index($targetIndexName) : $this->index;
+    }
+
+    /**
+     * Create a fresh, fully-configured build index for a zero-downtime rebuild
+     * and return its name. Index into it via addDocuments($docs, $name), then
+     * hand the name to swapBuildIndex().
+     *
+     * The setup tasks are awaited: if documents arrived before the primary key /
+     * settings were applied, Meilisearch could infer a wrong key or drop them.
+     */
+    public function createBuildIndex(): string {
+        $buildIndexName = $this->indexName . '-build';
+
+        // Drop a possible leftover build index from an aborted previous run.
+        try {
+            $this->client->waitForTask($this->client->deleteIndex($buildIndexName)['taskUid']);
+        } catch (\Throwable $e) {
+        }
+
+        $this->client->waitForTask($this->client->createIndex($buildIndexName)['taskUid']);
+        $buildIndex = $this->client->index($buildIndexName);
+        $this->client->waitForTask($buildIndex->update(['primaryKey' => 'id'])['taskUid']);
+        $this->client->waitForTask($buildIndex->updateSettings($this->indexSettings)['taskUid']);
+
+        return $buildIndexName;
+    }
+
+    /**
+     * Atomically swap a freshly-built index into the live index (native
+     * Meilisearch swap), then drop the old data. Aborts — leaving live
+     * untouched — if the build index is empty, so a broken build can never
+     * wipe search.
+     */
+    public function swapBuildIndex(string $buildIndexName): void {
+        $builtDocuments = $this->client->index($buildIndexName)->stats()['numberOfDocuments'] ?? 0;
+        if ($builtDocuments < 1) {
+            throw new Exception('Zero-downtime rebuild aborted: build index "' . $buildIndexName . '" is empty — live index left untouched.');
+        }
+
+        // Make sure the live index exists so the swap has two indexes.
+        try {
+            $this->client->waitForTask($this->client->createIndex($this->indexName)['taskUid']);
+        } catch (\Throwable $e) {
+        }
+
+        // Client::swapIndexes() wraps each pair in ['indexes' => ...] itself,
+        // so we pass the bare [live, build] pair — not a pre-wrapped payload.
+        $task = $this->client->swapIndexes([[$this->indexName, $buildIndexName]]);
+        $this->client->waitForTask($task['taskUid']);
+        $this->client->deleteIndex($buildIndexName);
+    }
+
+    /**
+     * Discard a build index (error cleanup); live is left untouched.
+     */
+    public function deleteBuildIndex(string $buildIndexName): void {
+        try {
+            $this->client->deleteIndex($buildIndexName);
+        } catch (\Throwable $e) {
+        }
+    }
+
     public function createIndex(): void {
         $this->client->createIndex($this->indexName);
         $this->index->updateSettings($this->indexSettings);
@@ -62,12 +126,14 @@ class MeilisearchIndex implements IndexInterface {
 
     /**
      * @param array $documents Documents to add to the index
+     * @param string|null $targetIndexName Write to this index instead of the live one (rebuild)
      * @return void
      * @throws TimeOutException
      */
-    public function addDocuments(array $documents): void {
-        $task = $this->index->addDocuments($documents);
-        $result = $this->index->waitForTask($task['taskUid']);
+    public function addDocuments(array $documents, ?string $targetIndexName = null): void {
+        $index = $this->targetIndex($targetIndexName);
+        $task = $index->addDocuments($documents);
+        $result = $index->waitForTask($task['taskUid']);
         if ($result['status'] !== 'succeeded') {
             throw new Exception('Meilisearch index update failed: ' . $result['error']['message']);
         }
@@ -75,10 +141,11 @@ class MeilisearchIndex implements IndexInterface {
 
     /**
      * @param array $documents Documents to delete from the index
+     * @param string|null $targetIndexName Delete from this index instead of the live one
      * @return void
      */
-    public function deleteDocuments(array $documents): void {
-        $this->index->deleteDocuments($documents);
+    public function deleteDocuments(array $documents, ?string $targetIndexName = null): void {
+        $this->targetIndex($targetIndexName)->deleteDocuments($documents);
     }
 
     /**
@@ -92,11 +159,12 @@ class MeilisearchIndex implements IndexInterface {
      * Delete documents matching the given Meilisearch filter expression.
      *
      * @param array<int,string>|string $filter
+     * @param string|null $targetIndexName Delete from this index instead of the live one
      * @return void
      */
-    public function deleteByFilter(array|string $filter): void {
+    public function deleteByFilter(array|string $filter, ?string $targetIndexName = null): void {
         $filterString = is_array($filter) ? implode(' AND ', $filter) : $filter;
-        $this->index->deleteDocuments(['filter' => $filterString]);
+        $this->targetIndex($targetIndexName)->deleteDocuments(['filter' => $filterString]);
     }
 
     /**

--- a/Classes/Domain/Service/MeilisearchIndex.php
+++ b/Classes/Domain/Service/MeilisearchIndex.php
@@ -5,6 +5,8 @@ namespace Medienreaktor\Meilisearch\Domain\Service;
 
 use Exception;
 use Meilisearch\Client;
+use Meilisearch\Contracts\DocumentsQuery;
+use Meilisearch\Contracts\IndexesQuery;
 use Meilisearch\Endpoints\Indexes;
 use Meilisearch\Exceptions\TimeOutException;
 use Meilisearch\Search\SearchResult;
@@ -14,6 +16,12 @@ use Neos\Flow\Annotations as Flow;
  * Meilisearch Index client
  */
 class MeilisearchIndex implements IndexInterface {
+    /**
+     * Marks an index as a rebuild scratch index; everything after it is the
+     * per-run suffix. Also used to recognise leftovers from aborted runs.
+     */
+    private const BUILD_INDEX_INFIX = '-build-';
+
     /**
      * @var string
      */
@@ -42,6 +50,12 @@ class MeilisearchIndex implements IndexInterface {
     protected $indexSettings;
 
     /**
+     * @Flow\InjectConfiguration(path="indexing", package="Medienreaktor.Meilisearch")
+     * @var array
+     */
+    protected $indexingSettings;
+
+    /**
      * @param string $indexName
      * @Flow\Autowiring(false)
      */
@@ -59,28 +73,106 @@ class MeilisearchIndex implements IndexInterface {
     }
 
     /**
+     * How long to wait for a Meilisearch task before giving up. The SDK's own
+     * default is 5 s, which a swap or a settings update on a production-sized
+     * index can exceed — the task then still completes, but the caller sees a
+     * TimeOutException and reports a successful rebuild as a failure.
+     */
+    protected function taskTimeout(): int {
+        return (int)($this->indexingSettings['taskTimeout'] ?? 300000);
+    }
+
+    /**
+     * Wait for a queued task and fail loudly if it did not succeed.
+     *
+     * @param array $task Task payload as returned by the client
+     * @throws Exception
+     */
+    protected function awaitTask(array $task): array {
+        $result = $this->client->waitForTask($task['taskUid'], $this->taskTimeout());
+        if (($result['status'] ?? null) !== 'succeeded') {
+            throw new Exception('Meilisearch task ' . ($task['type'] ?? 'unknown') . ' failed: ' . ($result['error']['message'] ?? 'no error message'));
+        }
+        return $result;
+    }
+
+    /**
      * Create a fresh, fully-configured build index for a zero-downtime rebuild
      * and return its name. Index into it via addDocuments($docs, $name), then
      * hand the name to swapBuildIndex().
+     *
+     * The name carries a per-run suffix so two rebuilds running at once cannot
+     * write into — or delete — each other's index.
      *
      * The setup tasks are awaited: if documents arrived before the primary key /
      * settings were applied, Meilisearch could infer a wrong key or drop them.
      */
     public function createBuildIndex(): string {
-        $buildIndexName = $this->indexName . '-build';
+        $this->deleteStaleBuildIndexes();
 
-        // Drop a possible leftover build index from an aborted previous run.
-        try {
-            $this->client->waitForTask($this->client->deleteIndex($buildIndexName)['taskUid']);
-        } catch (\Throwable $e) {
-        }
+        $buildIndexName = $this->indexName . self::BUILD_INDEX_INFIX . date('YmdHis') . '-' . bin2hex(random_bytes(3));
 
-        $this->client->waitForTask($this->client->createIndex($buildIndexName)['taskUid']);
+        $this->awaitTask($this->client->createIndex($buildIndexName));
         $buildIndex = $this->client->index($buildIndexName);
-        $this->client->waitForTask($buildIndex->update(['primaryKey' => 'id'])['taskUid']);
-        $this->client->waitForTask($buildIndex->updateSettings($this->indexSettings)['taskUid']);
+        $this->awaitTask($buildIndex->update(['primaryKey' => 'id']));
+        $this->awaitTask($buildIndex->updateSettings($this->indexSettings));
 
         return $buildIndexName;
+    }
+
+    /**
+     * Copy documents that this rebuild does not produce itself from the live
+     * index into the build index, so the swap does not drop them.
+     *
+     * Other packages write into the same index (the asset indexer stores its
+     * PDF/media documents next to the node documents). A node rebuild never
+     * touches those, so without this step every swap would silently wipe them.
+     * Each configured filter is copied under its own label; see the
+     * "indexing.preserveOnRebuild" setting.
+     *
+     * @param string $buildIndexName
+     * @return array<string,int> Number of copied documents per label
+     * @throws Exception
+     */
+    public function preserveDocuments(string $buildIndexName): array {
+        $filters = $this->indexingSettings['preserveOnRebuild'] ?? [];
+        if (!is_array($filters) || $filters === []) {
+            return [];
+        }
+
+        $batchSize = (int)($this->indexingSettings['batchSize'] ?? 100);
+        $copied = [];
+        foreach ($filters as $label => $filter) {
+            if (!is_string($filter) || trim($filter) === '') {
+                continue;
+            }
+            $copied[$label] = $this->copyDocumentsByFilter($filter, $buildIndexName, $batchSize);
+        }
+        return $copied;
+    }
+
+    /**
+     * Page through the live index and re-add every matching document to the
+     * build index. Uses the documents endpoint rather than search, because
+     * search paging is capped by maxTotalHits.
+     *
+     * @throws Exception
+     */
+    protected function copyDocumentsByFilter(string $filter, string $buildIndexName, int $batchSize): int {
+        $copied = 0;
+        $offset = 0;
+        do {
+            $query = (new DocumentsQuery())->setFilter([$filter])->setLimit($batchSize)->setOffset($offset);
+            $documents = $this->index->getDocuments($query)->getResults();
+            if ($documents === []) {
+                break;
+            }
+            $this->addDocuments($documents, $buildIndexName);
+            $copied += count($documents);
+            $offset += count($documents);
+        } while (count($documents) === $batchSize);
+
+        return $copied;
     }
 
     /**
@@ -97,15 +189,42 @@ class MeilisearchIndex implements IndexInterface {
 
         // Make sure the live index exists so the swap has two indexes.
         try {
-            $this->client->waitForTask($this->client->createIndex($this->indexName)['taskUid']);
+            $this->awaitTask($this->client->createIndex($this->indexName));
         } catch (\Throwable $e) {
         }
 
         // Client::swapIndexes() wraps each pair in ['indexes' => ...] itself,
         // so we pass the bare [live, build] pair — not a pre-wrapped payload.
-        $task = $this->client->swapIndexes([[$this->indexName, $buildIndexName]]);
-        $this->client->waitForTask($task['taskUid']);
+        $this->awaitTask($this->client->swapIndexes([[$this->indexName, $buildIndexName]]));
+        // The swap exchanged the contents, so this name now holds the old data.
         $this->client->deleteIndex($buildIndexName);
+    }
+
+    /**
+     * Drop build indexes left behind by an aborted run. Only indexes older than
+     * the configured TTL are removed — a younger one may belong to a rebuild
+     * that is still running.
+     */
+    protected function deleteStaleBuildIndexes(): void {
+        $prefix = $this->indexName . self::BUILD_INDEX_INFIX;
+        $ttl = (int)($this->indexingSettings['staleBuildIndexTtl'] ?? 86400);
+        $threshold = time() - $ttl;
+
+        try {
+            foreach ($this->client->getIndexes((new IndexesQuery())->setLimit(1000))->getResults() as $index) {
+                $uid = (string)$index->getUid();
+                if (!str_starts_with($uid, $prefix)) {
+                    continue;
+                }
+                $createdAt = $index->getCreatedAt();
+                if ($createdAt !== null && $createdAt->getTimestamp() > $threshold) {
+                    continue;
+                }
+                $this->client->deleteIndex($uid);
+            }
+        } catch (\Throwable $e) {
+            // Cleanup is best-effort; a leftover index costs disk, not correctness.
+        }
     }
 
     /**
@@ -131,12 +250,7 @@ class MeilisearchIndex implements IndexInterface {
      * @throws TimeOutException
      */
     public function addDocuments(array $documents, ?string $targetIndexName = null): void {
-        $index = $this->targetIndex($targetIndexName);
-        $task = $index->addDocuments($documents);
-        $result = $index->waitForTask($task['taskUid']);
-        if ($result['status'] !== 'succeeded') {
-            throw new Exception('Meilisearch index update failed: ' . $result['error']['message']);
-        }
+        $this->awaitTask($this->targetIndex($targetIndexName)->addDocuments($documents));
     }
 
     /**

--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -136,16 +136,20 @@ class NodeIndexer extends AbstractNodeIndexer {
      * @param string $targetWorkspace
      * @return void
      */
-    public function indexSingleNode(Node $node): void {
+    public function indexSingleNode(Node $node, bool $skipRemoval = false, ?string $targetIndexName = null): void {
         $node = $this->findFulltextRoot($node);
         if ($node !== null) {
-            $this->removeNode($node);
+            // The rebuild build index is fresh/empty, so the per-node delete is
+            // pure overhead; documents upsert by id, so skipping removal is safe.
+            if (!$skipRemoval) {
+                $this->removeNode($node, null, $targetIndexName);
+            }
             $nodeVariant = $this->extractNodeVariant($node, $node->dimensionSpacePoint);
             if ($nodeVariant !== null) {
                 $this->documentBuffer[] = $nodeVariant;
             }
             if (count($this->documentBuffer) >= $this->batchSize) {
-                $this->flushBuffer();
+                $this->flushBuffer($targetIndexName);
             }
         }
     }
@@ -191,22 +195,23 @@ class NodeIndexer extends AbstractNodeIndexer {
      *
      * @param Node $node
      * @param WorkspaceName|null $targetWorkspaceName
+     * @param string|null $targetIndexName Delete from this index instead of the live one (rebuild)
      * @return void
      */
-    public function removeNode(Node $node, WorkspaceName|null $targetWorkspaceName = null): void {
+    public function removeNode(Node $node, WorkspaceName|null $targetWorkspaceName = null, ?string $targetIndexName = null): void {
         $identifier = $this->generateUniqueNodeIdentifier($node);
-        $this->indexClient->deleteDocuments([$identifier]);
+        $this->indexClient->deleteDocuments([$identifier], $targetIndexName);
     }
 
-    public function flush(): void {
-        $this->flushBuffer();
+    public function flush(?string $targetIndexName = null): void {
+        $this->flushBuffer($targetIndexName);
     }
 
-    protected function flushBuffer(): void {
+    protected function flushBuffer(?string $targetIndexName = null): void {
         if (empty($this->documentBuffer)) {
             return;
         }
-        $this->indexClient->addDocuments($this->documentBuffer);
+        $this->indexClient->addDocuments($this->documentBuffer, $targetIndexName);
         $this->documentBuffer = [];
     }
 

--- a/Classes/Indexer/WorkspaceIndexer.php
+++ b/Classes/Indexer/WorkspaceIndexer.php
@@ -14,6 +14,7 @@ namespace Medienreaktor\Meilisearch\Indexer;
  */
 
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
@@ -52,21 +53,45 @@ final class WorkspaceIndexer
      * @param callable $callback
      * @return integer
      */
-    public function index(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, $limit = null, ?callable $callback = null, ?callable $singleCallback = null): int
+    public function index(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, $limit = null, ?callable $callback = null, ?callable $singleCallback = null, bool $skipRemoval = false, ?string $targetIndexName = null): int
     {
         $count = 0;
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $dimensionSpacePoints = $contentRepository->getVariationGraph()->getDimensionSpacePoints();
 
         if ($dimensionSpacePoints->isEmpty()) {
-            $count += $this->indexWithDimensions($contentRepositoryId, $workspaceName, DimensionSpacePoint::createWithoutDimensions(), $limit, $callback, $singleCallback);
+            $count += $this->indexWithDimensions($contentRepositoryId, $workspaceName, DimensionSpacePoint::createWithoutDimensions(), $limit, $callback, $singleCallback, $skipRemoval, $targetIndexName);
         } else {
             foreach ($dimensionSpacePoints as $dimensionSpacePoint) {
-                $count += $this->indexWithDimensions($contentRepositoryId, $workspaceName, $dimensionSpacePoint, $limit, $callback, $singleCallback);
+                $count += $this->indexWithDimensions($contentRepositoryId, $workspaceName, $dimensionSpacePoint, $limit, $callback, $singleCallback, $skipRemoval, $targetIndexName);
             }
         }
 
         return $count;
+    }
+
+    /**
+     * Counts how many nodes index() would visit (all descendants of the sites
+     * root across all dimensions). Cheap SQL COUNT, no nodes are materialised —
+     * used to give the build a determinate progress bar.
+     */
+    public function count(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName): int
+    {
+        $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
+        $dimensionSpacePoints = $contentRepository->getVariationGraph()->getDimensionSpacePoints();
+        $dimensionSpacePoints = $dimensionSpacePoints->isEmpty()
+            ? [DimensionSpacePoint::createWithoutDimensions()]
+            : $dimensionSpacePoints;
+
+        $contentGraph = $contentRepository->getContentGraph($workspaceName);
+        $rootNodeAggregate = $contentGraph->findRootNodeAggregateByType(NodeTypeNameFactory::forSites());
+
+        $total = 0;
+        foreach ($dimensionSpacePoints as $dimensionSpacePoint) {
+            $subgraph = $contentGraph->getSubgraph($dimensionSpacePoint, NeosVisibilityConstraints::excludeRemoved());
+            $total += $subgraph->countDescendantNodes($rootNodeAggregate->nodeAggregateId, CountDescendantNodesFilter::create());
+        }
+        return $total;
     }
 
     /**
@@ -76,7 +101,7 @@ final class WorkspaceIndexer
      * @param callable $callback
      * @return int
      */
-    public function indexWithDimensions(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint, ?int $limit = null, ?callable $callback = null, ?callable $singleCallback = null): int
+    public function indexWithDimensions(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint, ?int $limit = null, ?callable $callback = null, ?callable $singleCallback = null, bool $skipRemoval = false, ?string $targetIndexName = null): int
     {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $contentGraph = $contentRepository->getContentGraph($workspaceName);
@@ -87,7 +112,7 @@ final class WorkspaceIndexer
         $rootNode = $subgraph->findNodeById($rootNodeAggregate->nodeAggregateId);
         $indexedNodes = 0;
 
-        $this->nodeIndexer->indexSingleNode($rootNode);
+        $this->nodeIndexer->indexSingleNode($rootNode, $skipRemoval, $targetIndexName);
         $indexedNodes++;
 
         foreach ($subgraph->findDescendantNodes($rootNode->aggregateId, FindDescendantNodesFilter::create()) as $descendantNode) {
@@ -95,7 +120,7 @@ final class WorkspaceIndexer
                 break;
             }
 
-            $this->nodeIndexer->indexSingleNode($descendantNode);
+            $this->nodeIndexer->indexSingleNode($descendantNode, $skipRemoval, $targetIndexName);
             $indexedNodes++;
             if ($singleCallback !== null) {
                 $singleCallback($workspaceName, $indexedNodes, $dimensionSpacePoint);
@@ -103,7 +128,7 @@ final class WorkspaceIndexer
 
         };
 
-        $this->nodeIndexer->flush();
+        $this->nodeIndexer->flush($targetIndexName);
 
         if ($callback !== null) {
             $callback($workspaceName, $indexedNodes, $dimensionSpacePoint);

--- a/Classes/Indexer/WorkspaceIndexer.php
+++ b/Classes/Indexer/WorkspaceIndexer.php
@@ -13,8 +13,10 @@ namespace Medienreaktor\Meilisearch\Indexer;
  * source code.
  */
 
+use Medienreaktor\Meilisearch\Exception;
 use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\NodeType\NodeType;
 use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
@@ -50,11 +52,13 @@ final class WorkspaceIndexer {
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
     /**
-     * Lazily computed once per run (singleton): the node type criteria matching
-     * all fulltext roots. Iterating the node types on every dimension would be
-     * wasteful.
+     * Lazily computed once per run (singleton) and per content repository: the
+     * node type criteria matching all fulltext roots. Iterating the node types
+     * on every dimension would be wasteful.
+     *
+     * @var array<string,NodeTypeCriteria>
      */
-    private ?NodeTypeCriteria $fulltextRootCriteria = null;
+    private array $fulltextRootCriteria = [];
 
     /**
      * @param string $workspaceName
@@ -79,9 +83,9 @@ final class WorkspaceIndexer {
     }
 
     /**
-     * Counts how many nodes index() would visit (all descendants of the sites
-     * root across all dimensions). Cheap SQL COUNT, no nodes are materialised —
-     * used to give the build a determinate progress bar.
+     * Counts how many nodes index() would visit: the fulltext roots below the
+     * sites root plus the sites root itself, per dimension. Cheap SQL COUNT, no
+     * nodes are materialised — used to give the build a determinate progress bar.
      */
     public function count(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName): int {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
@@ -98,6 +102,8 @@ final class WorkspaceIndexer {
         foreach ($dimensionSpacePoints as $dimensionSpacePoint) {
             $subgraph = $contentGraph->getSubgraph($dimensionSpacePoint, NeosVisibilityConstraints::excludeRemoved());
             $total += $subgraph->countDescendantNodes($rootNodeAggregate->nodeAggregateId, CountDescendantNodesFilter::create(nodeTypes: $rootNodeTypeCriteria));
+            // The sites root itself is visited before the descendants.
+            $total++;
         }
         return $total;
     }
@@ -107,19 +113,73 @@ final class WorkspaceIndexer {
      * We only iterate those: each becomes one search document, and their content
      * descendants' fulltext is collected during extraction — so visiting the
      * content nodes themselves would just re-extract the same document.
+     *
+     * Only the types that declare isRoot themselves are named: NodeTypeCriteria
+     * expands every entry to its subtypes, so naming the inheriting types as
+     * well would only bloat the generated IN (...) — normally this comes down to
+     * the single abstract Neos.Neos:Document.
      */
     protected function fulltextRootNodeTypeCriteria(ContentRepository $contentRepository): NodeTypeCriteria {
-        if ($this->fulltextRootCriteria !== null) {
-            return $this->fulltextRootCriteria;
+        $cacheKey = $contentRepository->id->value;
+        if (isset($this->fulltextRootCriteria[$cacheKey])) {
+            return $this->fulltextRootCriteria[$cacheKey];
         }
-        $rootNodeTypeNames = [];
-        foreach ($contentRepository->getNodeTypeManager()->getNodeTypes(false) as $nodeType) {
+
+        $nodeTypeManager = $contentRepository->getNodeTypeManager();
+        $isFulltextRoot = static function (NodeType $nodeType): bool {
             $search = $nodeType->getConfiguration('search');
-            if (is_array($search) && ($search['fulltext']['isRoot'] ?? false) === true) {
-                $rootNodeTypeNames[] = $nodeType->name->value;
+            return is_array($search) && ($search['fulltext']['isRoot'] ?? false) === true;
+        };
+
+        $rootNodeTypes = [];
+        foreach ($nodeTypeManager->getNodeTypes(true) as $nodeType) {
+            if ($isFulltextRoot($nodeType)) {
+                $rootNodeTypes[$nodeType->name->value] = $nodeType;
             }
         }
-        return $this->fulltextRootCriteria = NodeTypeCriteria::createWithAllowedNodeTypeNames(NodeTypeNames::fromStringArray($rootNodeTypeNames));
+        if ($rootNodeTypes === []) {
+            // An empty allow-list means "everything" to NodeTypeCriteria, which would
+            // silently turn the fulltext-root filter into a full graph walk.
+            throw new Exception(sprintf(
+                'No node type in content repository "%s" is configured as a fulltext root (search.fulltext.isRoot). Refusing to index, because an empty criteria would match every node instead.',
+                $cacheKey
+            ), 1756100000);
+        }
+
+        $inheritsIsRoot = [];
+        $optedOut = [];
+        foreach ($rootNodeTypes as $rootNodeType) {
+            foreach ($nodeTypeManager->getSubNodeTypes($rootNodeType->name, true) as $subNodeType) {
+                if ($isFulltextRoot($subNodeType)) {
+                    $inheritsIsRoot[$subNodeType->name->value] = true;
+                } else {
+                    // Switched isRoot off again — it has to be excluded explicitly,
+                    // or the supertype's expansion would pull it back in.
+                    $optedOut[$subNodeType->name->value] = true;
+                }
+            }
+        }
+
+        // An exclusion is expanded to its subtypes too and wins over an inclusion,
+        // so a type that opts out while one of its own subtypes re-enables isRoot
+        // cannot be expressed. Keep such a type in: visiting a few extra nodes only
+        // costs time (they resolve to their nearest fulltext root), whereas
+        // excluding them would drop documents from the index.
+        foreach (array_keys($optedOut) as $optedOutNodeTypeName) {
+            foreach ($nodeTypeManager->getSubNodeTypes($optedOutNodeTypeName, true) as $subNodeType) {
+                if ($isFulltextRoot($subNodeType)) {
+                    unset($optedOut[$optedOutNodeTypeName]);
+                    break;
+                }
+            }
+        }
+
+        $declaringNodeTypeNames = array_values(array_diff(array_keys($rootNodeTypes), array_keys($inheritsIsRoot)));
+
+        return $this->fulltextRootCriteria[$cacheKey] = NodeTypeCriteria::create(
+            NodeTypeNames::fromStringArray($declaringNodeTypeNames),
+            NodeTypeNames::fromStringArray(array_keys($optedOut))
+        );
     }
 
     /**
@@ -141,12 +201,18 @@ final class WorkspaceIndexer {
 
         $this->nodeIndexer->indexSingleNode($rootNode, $skipRemoval, $targetIndexName);
         $indexedNodes++;
+        if ($singleCallback !== null) {
+            $singleCallback($workspaceName, $indexedNodes, $dimensionSpacePoint);
+        }
 
         foreach ($subgraph->findDescendantNodes(
             $rootNode->aggregateId,
             FindDescendantNodesFilter::create(nodeTypes: $this->fulltextRootNodeTypeCriteria($contentRepository)))
                  as $descendantNode) {
-            if ($limit !== null && $indexedNodes > $limit) {
+            // $indexedNodes already counts the sites root, so this caps the visited
+            // nodes at exactly $limit per dimension — which is what the progress
+            // bar's maximum is calculated from.
+            if ($limit !== null && $indexedNodes >= $limit) {
                 break;
             }
 

--- a/Classes/Indexer/WorkspaceIndexer.php
+++ b/Classes/Indexer/WorkspaceIndexer.php
@@ -13,9 +13,12 @@ namespace Medienreaktor\Meilisearch\Indexer;
  * source code.
  */
 
+use Neos\ContentRepository\Core\ContentRepository;
 use Neos\ContentRepository\Core\DimensionSpace\DimensionSpacePoint;
+use Neos\ContentRepository\Core\NodeType\NodeTypeNames;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\CountDescendantNodesFilter;
 use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\FindDescendantNodesFilter;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Filter\NodeType\NodeTypeCriteria;
 use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
 use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
 use Neos\ContentRepository\Search\Indexer\NodeIndexingManager;
@@ -29,8 +32,7 @@ use Neos\Neos\Domain\SubtreeTagging\NeosVisibilityConstraints;
  *
  * @Flow\Scope("singleton")
  */
-final class WorkspaceIndexer
-{
+final class WorkspaceIndexer {
     /**
      * @var NodeIndexingManager
      * @Flow\Inject
@@ -48,13 +50,19 @@ final class WorkspaceIndexer
     protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
     /**
+     * Lazily computed once per run (singleton): the node type criteria matching
+     * all fulltext roots. Iterating the node types on every dimension would be
+     * wasteful.
+     */
+    private ?NodeTypeCriteria $fulltextRootCriteria = null;
+
+    /**
      * @param string $workspaceName
      * @param integer $limit
      * @param callable $callback
      * @return integer
      */
-    public function index(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, $limit = null, ?callable $callback = null, ?callable $singleCallback = null, bool $skipRemoval = false, ?string $targetIndexName = null): int
-    {
+    public function index(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, $limit = null, ?callable $callback = null, ?callable $singleCallback = null, bool $skipRemoval = false, ?string $targetIndexName = null): int {
         $count = 0;
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $dimensionSpacePoints = $contentRepository->getVariationGraph()->getDimensionSpacePoints();
@@ -75,8 +83,7 @@ final class WorkspaceIndexer
      * root across all dimensions). Cheap SQL COUNT, no nodes are materialised —
      * used to give the build a determinate progress bar.
      */
-    public function count(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName): int
-    {
+    public function count(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName): int {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $dimensionSpacePoints = $contentRepository->getVariationGraph()->getDimensionSpacePoints();
         $dimensionSpacePoints = $dimensionSpacePoints->isEmpty()
@@ -86,12 +93,33 @@ final class WorkspaceIndexer
         $contentGraph = $contentRepository->getContentGraph($workspaceName);
         $rootNodeAggregate = $contentGraph->findRootNodeAggregateByType(NodeTypeNameFactory::forSites());
 
+        $rootNodeTypeCriteria = $this->fulltextRootNodeTypeCriteria($contentRepository);
         $total = 0;
         foreach ($dimensionSpacePoints as $dimensionSpacePoint) {
             $subgraph = $contentGraph->getSubgraph($dimensionSpacePoint, NeosVisibilityConstraints::excludeRemoved());
-            $total += $subgraph->countDescendantNodes($rootNodeAggregate->nodeAggregateId, CountDescendantNodesFilter::create());
+            $total += $subgraph->countDescendantNodes($rootNodeAggregate->nodeAggregateId, CountDescendantNodesFilter::create(nodeTypes: $rootNodeTypeCriteria));
         }
         return $total;
+    }
+
+    /**
+     * Node type criteria matching every fulltext root (search.fulltext.isRoot).
+     * We only iterate those: each becomes one search document, and their content
+     * descendants' fulltext is collected during extraction — so visiting the
+     * content nodes themselves would just re-extract the same document.
+     */
+    protected function fulltextRootNodeTypeCriteria(ContentRepository $contentRepository): NodeTypeCriteria {
+        if ($this->fulltextRootCriteria !== null) {
+            return $this->fulltextRootCriteria;
+        }
+        $rootNodeTypeNames = [];
+        foreach ($contentRepository->getNodeTypeManager()->getNodeTypes(false) as $nodeType) {
+            $search = $nodeType->getConfiguration('search');
+            if (is_array($search) && ($search['fulltext']['isRoot'] ?? false) === true) {
+                $rootNodeTypeNames[] = $nodeType->name->value;
+            }
+        }
+        return $this->fulltextRootCriteria = NodeTypeCriteria::createWithAllowedNodeTypeNames(NodeTypeNames::fromStringArray($rootNodeTypeNames));
     }
 
     /**
@@ -101,8 +129,7 @@ final class WorkspaceIndexer
      * @param callable $callback
      * @return int
      */
-    public function indexWithDimensions(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint, ?int $limit = null, ?callable $callback = null, ?callable $singleCallback = null, bool $skipRemoval = false, ?string $targetIndexName = null): int
-    {
+    public function indexWithDimensions(ContentRepositoryId $contentRepositoryId, WorkspaceName $workspaceName, DimensionSpacePoint $dimensionSpacePoint, ?int $limit = null, ?callable $callback = null, ?callable $singleCallback = null, bool $skipRemoval = false, ?string $targetIndexName = null): int {
         $contentRepository = $this->contentRepositoryRegistry->get($contentRepositoryId);
         $contentGraph = $contentRepository->getContentGraph($workspaceName);
 
@@ -115,7 +142,10 @@ final class WorkspaceIndexer
         $this->nodeIndexer->indexSingleNode($rootNode, $skipRemoval, $targetIndexName);
         $indexedNodes++;
 
-        foreach ($subgraph->findDescendantNodes($rootNode->aggregateId, FindDescendantNodesFilter::create()) as $descendantNode) {
+        foreach ($subgraph->findDescendantNodes(
+            $rootNode->aggregateId,
+            FindDescendantNodesFilter::create(nodeTypes: $this->fulltextRootNodeTypeCriteria($contentRepository)))
+                 as $descendantNode) {
             if ($limit !== null && $indexedNodes > $limit) {
                 break;
             }

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -16,6 +16,19 @@ Medienreaktor:
     indexing:
       batchSize: 100
       maxFulltextBytes: 500000
+      # How long (ms) to wait for a queued Meilisearch task. The SDK default of
+      # 5000 is too short for a swap or a settings update on a large index: the
+      # task still completes, but the client gives up and the command exits 1.
+      taskTimeout: 300000
+      # Age (seconds) after which a build index left behind by an aborted
+      # nodeindex:rebuild is dropped. Younger ones may belong to a running build.
+      staleBuildIndexTtl: 86400
+      # Documents a node rebuild does not produce itself but that live in the same
+      # index, as "label: <Meilisearch filter>". They are copied into the build
+      # index before the swap, which would otherwise drop them. Packages that
+      # write their own documents (e.g. the asset indexer) add their filter here.
+      # Every attribute used must be in settings.filterableAttributes.
+      preserveOnRebuild: {}
     client:
       endpoint: 'http://meilisearch:7700'
       apiKey: '1234'

--- a/README.md
+++ b/README.md
@@ -87,6 +87,32 @@ Medienreaktor:
 
 Please do not remove, only extend, above `filterableAttributes`, as they are needed for base functionality to work. After finishing or changing configuration, build the node index once via the CLI command `flow nodeindex:build`.
 
+### Rebuilding without downtime
+
+`flow nodeindex:build` writes into the live index, so while it runs the index is
+incomplete. `flow nodeindex:rebuild` instead builds into a temporary index and
+swaps it live in one atomic step; if anything fails, the temporary index is
+discarded and the live index is left untouched.
+
+`--limit <n>` caps the number of indexed nodes per dimension for a quick check of
+the build itself. Such a partial index is never swapped live.
+
+Other packages may write their own documents into the same index (the asset
+indexer stores its media and PDF documents next to the node documents). A node
+rebuild does not produce those, so they must be listed for the swap to keep them:
+
+```yaml
+Medienreaktor:
+  Meilisearch:
+    indexing:
+      preserveOnRebuild:
+        assets: '__isAsset = true'
+```
+
+Every document matching such a filter is copied from the live index into the
+temporary index before the swap. The attributes used in a filter must be part of
+`settings.filterableAttributes`.
+
 Document NodeTypes should be configured as fulltext root (this comes by default for all `Neos.Neos:Document` subtypes):
 
 ```yaml

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,55 @@
     "description": "Integrates Meilisearch into Neos.",
     "license": "MIT",
     "require": {
+        "php": "^8.2",
+        "neos/flow": "^9.0",
+        "neos/neos": "^9.0",
+        "neos/eel": "^9.0",
+        "neos/media": "^9.0",
+        "neos/contentrepository-core": "^9.0",
+        "neos/contentrepositoryregistry": "^9.0",
         "neos/content-repository-search": "^5.0",
-        "meilisearch/meilisearch-php": "*",
-        "guzzlehttp/guzzle": "*",
+        "meilisearch/meilisearch-php": "^1.2",
+        "guzzlehttp/guzzle": "^7.0",
         "http-interop/http-factory-guzzle": "^1.0"
+    },
+    "require-dev": {
+        "neos/contentgraph-doctrinedbaladapter": "^9.0",
+        "phpunit/phpunit": "^10.5 || ^11.5",
+        "phpstan/phpstan": "^2.1",
+        "squizlabs/php_codesniffer": "^4.0"
     },
     "autoload": {
         "psr-4": {
             "Medienreaktor\\Meilisearch\\": "Classes/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Medienreaktor\\Meilisearch\\Tests\\": "Tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "neos/composer-plugin": true
+        }
+    },
+    "extra": {
+        "neos": {
+            "package-key": "Medienreaktor.Meilisearch"
+        },
+        "branch-alias": {
+            "dev-neos9": "3.x-dev"
+        }
+    },
+    "scripts": {
+        "test": "./vendor/bin/phpunit",
+        "lint:phpstan": "@php vendor/bin/phpstan analyse",
+        "lint:phpcs": "./vendor/bin/phpcs --colors",
+        "lint:phpcs:fix": "./vendor/bin/phpcbf --colors",
+        "lint": [
+            "@lint:phpcs",
+            "@lint:phpstan"
+        ]
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" ?>
+<ruleset name="PSR12">
+    <description>The PSR12 coding standard – without line length limitation</description>
+
+    <!-- Tests/ is not part of this branch yet; add it back together with the suite. -->
+    <file>./Classes</file>
+
+    <rule ref="PSR12">
+        <exclude name="Generic.Files.LineLength.TooLong" />
+    </rule>
+</ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,10 @@
+parameters:
+    level: 5
+    # Tests/ is not part of this branch yet; add it back together with the suite.
+    paths:
+        - Classes
+    # The package declares php ^8.2 — the floor neos/flow ^9 and
+    # neos/content-repository-search ^5 both impose — so analyse against that
+    # rather than the interpreter in use, or 8.3-only syntax passes locally and
+    # breaks the oldest supported target.
+    phpVersion: 80200

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    The PHP floor on this branch is 8.2 (neos/flow ^9), so PHPUnit 9.6 is out of
+    range and the schema can stay on what 10.5 and 11.5 share.
+
+    There is no test suite on this line yet — the Neos 9 port did not carry one
+    over. failOnEmptyTestSuite stays false (PHPUnit's default, spelled out here so
+    it is not switched on by accident) so the job reports green on an empty run
+    rather than blocking CI on tests nobody has written. Tests/Unit itself has to
+    exist: PHPUnit treats a missing directory as a configuration error, not as an
+    empty suite. Once the suite lands, this comment goes with it.
+-->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnEmptyTestSuite="false">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## Was

`nodeindex:rebuild`: Reindex ohne Downtime. Baut in einen Temp-Index und tauscht ihn am Ende atomar gegen den Live-Index.

## Entscheidungen (jeweils warum)

- Blue-Green statt In-Place, weil `build` pro Node direkt am Live-Index löscht und schreibt (kurze Trefferlücken); `rebuild` baut separat und swappt erst am Schluss.

- Nativer Meilisearch-Swap (atomar, keine Downtime); das SDK wrappt das Paar selbst, daher `swapIndexes([[$this->indexName, $buildIndexName]])` statt vorgewrappt.

- Ziel-Index explizit durchgereicht statt geteiltem Instanz-State (war fragil), damit Writes deterministisch im Build-Index landen: `addDocuments(array $documents, ?string $targetIndexName = null)`.

- Setup-Tasks werden abgewartet, sonst treffen Docs vor PrimaryKey/Settings ein und gehen verloren: `$this->client->waitForTask($buildIndex->update(['primaryKey' => 'id'])['taskUid'])`.

- Guard: ein leerer Build-Index wird nie live geswappt, damit ein kaputter Build die Suche nicht leert: `if ($builtDocuments < 1) { throw new Exception('... left untouched'); }`.

- Nur Fulltext-Roots iterieren statt aller Nodes, weil sonst jeder Content-Node sein Dokument erneut komplett aus der DB extrahiert (~21x): `findDescendantNodes(..., FindDescendantNodesFilter::create(nodeTypes: <alle search.fulltext.isRoot-Typen>))`. `count()` nutzt denselben Filter; das Kriterium wird pro Lauf gecacht.

- `skipRemoval` beim Rebuild, weil der Build-Index frisch/leer ist und das Löschen pro Node nur Overhead ist: `if (!$skipRemoval) { $this->removeNode(...); }`.

- Determinate Progress-Bar über einen günstigen COUNT (materialisiert keine Nodes): `$subgraph->countDescendantNodes(...)`.

- `--limit` fuer schnelle Tests statt 30-Min-Laeufen; das Limit gilt pro Dimension, daher Progress-Max `= $limit * $dimensionSpacePoints->count()`.

## Performance (voller Rebuild, SWK-Datensatz)

| | vorher (alle Nodes) | nachher (nur Roots) |
|---|---|---|
| Dauer | 943 s (~15:43 min) | **47 s (~20x)** |
| besuchte Nodes | 42.783 | 3.442 |
| Ergebnis | 2020 docs, Treffer 52/33/106/3/76 | identisch |

Der eigentliche Bottleneck war die Duplikat-Extraktion, nicht Meilisearch. `skipRemoval` bringt separat nur ~5-10%.

## Nicht breaking

Nur additive optionale Parameter an bestehenden Methoden; der Realtime-Pfad (`indexNode`) schreibt unveraendert in den Live-Index (Default). Das Interface bekommt neue Methoden, hat aber nur eine Implementierung.

## Nutzung

`./flow nodeindex:rebuild` (voll), `./flow nodeindex:rebuild --limit 100` (Test, erzeugt partiellen Index).
